### PR TITLE
Legger til endepunkt for altinnrettigheter

### DIFF
--- a/src/main/kotlin/no/nav/helse/fritakagp/koin/Fakes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/koin/Fakes.kt
@@ -1,0 +1,91 @@
+package no.nav.helse.fritakagp.koin
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.helse.arbeidsgiver.integrasjoner.altinn.AltinnOrganisasjon
+import no.nav.helse.arbeidsgiver.integrasjoner.dokarkiv.DokarkivKlient
+import no.nav.helse.arbeidsgiver.integrasjoner.dokarkiv.JournalpostRequest
+import no.nav.helse.arbeidsgiver.integrasjoner.dokarkiv.JournalpostResponse
+import no.nav.helse.arbeidsgiver.integrasjoner.oppgave.OppgaveKlient
+import no.nav.helse.arbeidsgiver.integrasjoner.oppgave.OpprettOppgaveRequest
+import no.nav.helse.arbeidsgiver.integrasjoner.oppgave.OpprettOppgaveResponse
+import no.nav.helse.arbeidsgiver.integrasjoner.pdl.*
+import no.nav.helse.arbeidsgiver.utils.loadFromResources
+import no.nav.helse.arbeidsgiver.web.auth.AltinnOrganisationsRepository
+import no.nav.helse.fritakagp.integration.gcp.BucketStorage
+import no.nav.helse.fritakagp.integration.gcp.MockBucketStorage
+import no.nav.helse.fritakagp.integration.virusscan.MockVirusScanner
+import no.nav.helse.fritakagp.integration.virusscan.VirusScanner
+import org.koin.core.module.Module
+import org.koin.dsl.bind
+
+fun Module.mockExternalDependecies() {
+    single { MockAltinnRepo(get()) } bind AltinnOrganisationsRepository::class
+
+    single {
+        object : DokarkivKlient {
+            override fun journalførDokument(
+                journalpost: JournalpostRequest,
+                forsoekFerdigstill: Boolean,
+                callId: String
+            ): JournalpostResponse {
+                return JournalpostResponse("arkiv-ref", true, "J", null, emptyList())
+            }
+        }
+    } bind DokarkivKlient::class
+
+    single {
+        object : PdlClient {
+            override fun fullPerson(ident: String) =
+                PdlHentFullPerson(
+                    PdlHentFullPerson.PdlFullPersonliste(
+                        emptyList(),
+                        emptyList(),
+                        emptyList(),
+                        emptyList(),
+                        emptyList()
+                    ),
+
+                    PdlHentFullPerson.PdlIdentResponse(listOf(PdlIdent("aktør-id", PdlIdent.PdlIdentGruppe.AKTORID))),
+
+                    PdlHentFullPerson.PdlGeografiskTilknytning(
+                        PdlHentFullPerson.PdlGeografiskTilknytning.PdlGtType.UTLAND,
+                        null,
+                        null,
+                        "SWE"
+                    )
+                )
+
+            override fun personNavn(ident: String) =
+                PdlHentPersonNavn.PdlPersonNavneliste(
+                    listOf(
+                        PdlHentPersonNavn.PdlPersonNavneliste.PdlPersonNavn(
+                            "Ola",
+                            "M",
+                            "Avsender",
+                            PdlPersonNavnMetadata("freg")
+                        )
+                    )
+                )
+        }
+
+    } bind PdlClient::class
+
+    single {
+        object : OppgaveKlient {
+            override suspend fun opprettOppgave(
+                opprettOppgaveRequest: OpprettOppgaveRequest,
+                callId: String
+            ): OpprettOppgaveResponse = OpprettOppgaveResponse(1234)
+        }
+    } bind OppgaveKlient::class
+
+    single { MockVirusScanner() } bind VirusScanner::class
+    single { MockBucketStorage() } bind BucketStorage::class
+}
+
+class MockAltinnRepo(om: ObjectMapper) : AltinnOrganisationsRepository {
+    private val mockList = "altinn-mock/organisasjoner-med-rettighet.json".loadFromResources()
+    private val mockAcl = om.readValue<Set<AltinnOrganisasjon>>(mockList)
+    override fun hentOrgMedRettigheterForPerson(identitetsnummer: String): Set<AltinnOrganisasjon> = mockAcl
+}

--- a/src/main/kotlin/no/nav/helse/fritakagp/koin/KoinProfiles.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/koin/KoinProfiles.kt
@@ -9,11 +9,13 @@ import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.ktor.client.*
 import io.ktor.client.engine.apache.*
 import io.ktor.client.features.json.*
 import io.ktor.config.*
 import io.ktor.util.*
+import no.nav.helse.arbeidsgiver.integrasjoner.altinn.AltinnOrganisasjon
 import no.nav.helse.arbeidsgiver.integrasjoner.dokarkiv.DokarkivKlient
 import no.nav.helse.arbeidsgiver.integrasjoner.dokarkiv.JournalpostRequest
 import no.nav.helse.arbeidsgiver.integrasjoner.dokarkiv.JournalpostResponse
@@ -22,6 +24,8 @@ import no.nav.helse.arbeidsgiver.integrasjoner.oppgave.OpprettOppgaveRequest
 import no.nav.helse.arbeidsgiver.integrasjoner.oppgave.OpprettOppgaveResponse
 import no.nav.helse.arbeidsgiver.integrasjoner.pdl.*
 import no.nav.helse.arbeidsgiver.kubernetes.KubernetesProbeManager
+import no.nav.helse.arbeidsgiver.utils.loadFromResources
+import no.nav.helse.arbeidsgiver.web.auth.AltinnOrganisationsRepository
 import no.nav.helse.fritakagp.integration.gcp.BucketStorage
 import no.nav.helse.fritakagp.integration.gcp.MockBucketStorage
 import no.nav.helse.fritakagp.integration.virusscan.MockVirusScanner
@@ -81,58 +85,6 @@ val common = module {
 
 }
 
-fun Module.mockExternalDependecies() {
-    single { object: DokarkivKlient {
-        override fun journalførDokument(
-            journalpost: JournalpostRequest,
-            forsoekFerdigstill: Boolean,
-            callId: String
-        ): JournalpostResponse {
-            return JournalpostResponse("arkiv-ref", true, "J", null, emptyList())
-        }
-    } } bind DokarkivKlient::class
-
-    single {object: PdlClient {
-        override fun fullPerson(ident: String) =
-            PdlHentFullPerson(
-                PdlHentFullPerson.PdlFullPersonliste(
-                    emptyList(),
-                    emptyList(),
-                    emptyList(),
-                    emptyList(),
-                    emptyList()
-                ),
-
-                PdlHentFullPerson.PdlIdentResponse(listOf(PdlIdent("aktør-id", PdlIdent.PdlIdentGruppe.AKTORID))),
-
-                PdlHentFullPerson.PdlGeografiskTilknytning(
-                    PdlHentFullPerson.PdlGeografiskTilknytning.PdlGtType.UTLAND,
-                    null,
-                    null,
-                    "SWE"
-                )
-            )
-
-        override fun personNavn(ident: String) =
-            PdlHentPersonNavn.PdlPersonNavneliste(listOf(
-                PdlHentPersonNavn.PdlPersonNavneliste.PdlPersonNavn("Ola", "M", "Avsender", PdlPersonNavnMetadata("freg"))))
-    }
-
-    } bind PdlClient::class
-
-    single { object: OppgaveKlient {
-        override suspend fun opprettOppgave(
-            opprettOppgaveRequest: OpprettOppgaveRequest,
-            callId: String
-        ): OpprettOppgaveResponse = OpprettOppgaveResponse(1234)
-    } } bind OppgaveKlient::class
-
-    single { MockVirusScanner() } bind VirusScanner::class
-    single { MockBucketStorage() } bind BucketStorage::class
-}
-
-
-
 // utils
 @KtorExperimentalAPI
 fun ApplicationConfig.getString(path: String): String {
@@ -141,18 +93,20 @@ fun ApplicationConfig.getString(path: String): String {
 
 @KtorExperimentalAPI
 fun ApplicationConfig.getjdbcUrlFromProperties(): String {
-    return String.format("jdbc:postgresql://%s:%s/%s",
-            this.property("database.host").getString(),
-            this.property("database.port").getString(),
-            this.property("database.name").getString())
+    return String.format(
+        "jdbc:postgresql://%s:%s/%s",
+        this.property("database.host").getString(),
+        this.property("database.port").getString(),
+        this.property("database.name").getString()
+    )
 }
 
 
 inline fun <reified T : Any> Koin.getAllOfType(): Collection<T> =
-        let { koin ->
-            koin.rootScope.beanRegistry
-                    .getAllDefinitions()
-                    .filter { it.kind == Kind.Single }
-                    .map { koin.get<Any>(clazz = it.primaryType, qualifier = null, parameters = null) }
-                    .filterIsInstance<T>()
-        }
+    let { koin ->
+        koin.rootScope.beanRegistry
+            .getAllDefinitions()
+            .filter { it.kind == Kind.Single }
+            .map { koin.get<Any>(clazz = it.primaryType, qualifier = null, parameters = null) }
+            .filterIsInstance<T>()
+    }

--- a/src/main/kotlin/no/nav/helse/fritakagp/koin/LocalKoinProfile.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/koin/LocalKoinProfile.kt
@@ -21,7 +21,7 @@ import javax.sql.DataSource
 @KtorExperimentalAPI
 fun localDevConfig(config: ApplicationConfig) = module {
 
-    this.mockExternalDependecies()
+    mockExternalDependecies()
 
     single { HikariDataSource(createHikariConfig(config.getjdbcUrlFromProperties(), config.getString("database.username"), config.getString("database.password"))) } bind DataSource::class
     single { PostgresGravidSoeknadRepository(get(), get()) } bind GravidSoeknadRepository::class

--- a/src/main/kotlin/no/nav/helse/fritakagp/koin/PreprodKoinProfile.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/koin/PreprodKoinProfile.kt
@@ -14,6 +14,7 @@ import no.nav.helse.arbeidsgiver.integrasjoner.oppgave.OppgaveKlient
 import no.nav.helse.arbeidsgiver.integrasjoner.oppgave.OppgaveKlientImpl
 import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlClient
 import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlClientImpl
+import no.nav.helse.arbeidsgiver.web.auth.AltinnOrganisationsRepository
 import no.nav.helse.fritakagp.MetrikkVarsler
 import no.nav.helse.fritakagp.db.*
 import no.nav.helse.fritakagp.integration.gcp.BucketStorage
@@ -88,6 +89,7 @@ fun preprodConfig(config: ApplicationConfig) = module {
 }
 
 fun Module.externalSystemClients(config: ApplicationConfig) {
+    single { MockAltinnRepo(get()) } bind AltinnOrganisationsRepository::class
 
     single {
         val clientConfig = OAuth2ClientPropertiesConfig(config)

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/FritakModule.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/FritakModule.kt
@@ -1,8 +1,6 @@
 package no.nav.helse.fritakagp.web
 
-import com.fasterxml.jackson.databind.JsonMappingException
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
 import io.ktor.application.*
 import io.ktor.auth.*
 import io.ktor.config.*
@@ -10,25 +8,16 @@ import io.ktor.features.*
 import io.ktor.http.*
 import io.ktor.jackson.*
 import io.ktor.locations.*
-import io.ktor.response.*
 import io.ktor.routing.*
 import io.ktor.util.*
 import no.nav.helse.arbeidsgiver.system.AppEnv
 import no.nav.helse.arbeidsgiver.system.getEnvironment
-import no.nav.helse.arbeidsgiver.web.validation.Problem
-import no.nav.helse.arbeidsgiver.web.validation.ValidationProblem
-import no.nav.helse.arbeidsgiver.web.validation.ValidationProblemDetail
-import no.nav.helse.fritakagp.web.api.fritakAGP
-import no.nav.helse.fritakagp.web.dto.validation.getContextualMessage
+import no.nav.helse.fritakagp.web.api.altinnRoutes
+import no.nav.helse.fritakagp.web.api.configureExceptionHandling
+import no.nav.helse.fritakagp.web.api.fritakAGPRoutes
 import no.nav.security.token.support.ktor.tokenValidationSupport
 import org.koin.ktor.ext.get
-import org.slf4j.LoggerFactory
-import org.valiktor.ConstraintViolationException
-import java.lang.reflect.InvocationTargetException
-import java.net.URI
 import java.time.LocalDate
-import java.util.*
-import javax.ws.rs.ForbiddenException
 
 
 @KtorExperimentalLocationsAPI
@@ -39,145 +28,35 @@ fun Application.fritakModule(config: ApplicationConfig = environment.config) {
         tokenValidationSupport(config = config)
     }
 
-    install(CORS)
-    {
-        method(HttpMethod.Options)
-        method(HttpMethod.Post)
-        method(HttpMethod.Get)
-
-        when(config.getEnvironment()) {
-            AppEnv.TEST -> anyHost()
-            AppEnv.LOCAL -> anyHost()
-            AppEnv.PREPROD -> anyHost()
-            AppEnv.PROD -> host("arbeidsgiver.nav.no", schemes = listOf("https"))
-        }
-
-        allowCredentials = true
-        allowNonSimpleContentTypes = true
-    }
-
-    install(Locations)
+    configureCORSAccess(config)
+    configureExceptionHandling()
 
     install(ContentNegotiation) {
         val commonObjectMapper = get<ObjectMapper>()
         register(ContentType.Application.Json, JacksonConverter(commonObjectMapper))
     }
 
-    install(DataConversion) {
-        convert<LocalDate> {
-            decode { values, _ ->
-                values.singleOrNull()?.let { LocalDate.parse(it) }
-            }
-
-            encode { value ->
-                when (value) {
-                    null -> listOf()
-                    is LocalDate -> listOf(value.toString())
-                    else -> throw DataConversionException("Cannot convert $value as LocalDate")
-                }
-            }
-        }
-    }
-
-    install(StatusPages) {
-        val LOGGER = LoggerFactory.getLogger("StatusPages")
-
-        suspend fun handleUnexpectedException(call: ApplicationCall, cause: Throwable) {
-            val errorId = UUID.randomUUID()
-            val userAgent = call.request.headers.get("User-Agent") ?: "Ukjent"
-            LOGGER.error("Uventet feil, $errorId med useragent $userAgent", cause)
-            val problem = Problem(
-                    type = URI.create("urn:fritak:uventet-feil"),
-                    title = "Uventet feil",
-                    detail = cause.message,
-                    instance = URI.create("urn:fritak:uventent-feil:$errorId")
-            )
-            call.respond(HttpStatusCode.InternalServerError, problem)
-        }
-
-        suspend fun handleValidationError(call: ApplicationCall, cause: ConstraintViolationException) {
-            val problems = cause.constraintViolations.map {
-                ValidationProblemDetail(it.constraint.name, it.getContextualMessage(), it.property, it.value)
-            }.toSet()
-
-            problems
-                    .filter {
-                        it.propertyPath.contains("perioder")
-                    }
-                    .forEach {
-                        LOGGER.warn("Invalid ${it.propertyPath}: ${it.invalidValue} (${it.message})")
-                    }
-
-            call.respond(HttpStatusCode.UnprocessableEntity, ValidationProblem(problems))
-        }
-
-        exception<InvocationTargetException> { cause ->
-            when (cause.targetException) {
-                is ConstraintViolationException -> handleValidationError(call, cause.targetException as ConstraintViolationException)
-                else -> handleUnexpectedException(call, cause)
-            }
-        }
-
-        exception<ForbiddenException> {
-            call.respond(
-                    HttpStatusCode.Forbidden,
-                    Problem(URI.create("urn:fritak:forbidden"), "Ingen tilgang", HttpStatusCode.Forbidden.value)
-            )
-        }
-
-        exception<Throwable> { cause ->
-            handleUnexpectedException(call, cause)
-        }
-
-        exception<ParameterConversionException> { cause ->
-            call.respond(
-                    HttpStatusCode.BadRequest,
-                    ValidationProblem(setOf(
-                            ValidationProblemDetail("ParameterConversion", "Parameteret kunne ikke  konverteres til ${cause.type}", cause.parameterName, null))
-                    )
-            )
-            LOGGER.warn("${cause.parameterName} kunne ikke konverteres")
-        }
-
-        exception<MissingKotlinParameterException> { cause ->
-            val userAgent = call.request.headers.get("User-Agent") ?: "Ukjent"
-            call.respond(
-                    HttpStatusCode.BadRequest,
-                    ValidationProblem(setOf(
-                            ValidationProblemDetail("NotNull", "Det angitte feltet er påkrevd", cause.path.filter { it.fieldName != null }.joinToString(".") {
-                                it.fieldName
-                            }, "null"))
-                    )
-            )
-            LOGGER.warn("Feil med validering av ${cause.parameter.name ?: "Ukjent"} for ${userAgent}: ${cause.message}")
-        }
-
-        exception<JsonMappingException> { cause ->
-            if (cause.cause is ConstraintViolationException) {
-                handleValidationError(call, cause.cause as ConstraintViolationException)
-            } else {
-                val errorId = UUID.randomUUID()
-                val userAgent = call.request.headers.get("User-Agent") ?: "Ukjent"
-                val locale = call.request.headers.get("Accept-Language") ?: "Ukjent"
-                LOGGER.warn("$errorId : $userAgent : $locale", cause)
-                val problem = Problem(
-                        status = HttpStatusCode.BadRequest.value,
-                        title = "Feil ved prosessering av JSON-dataene som ble oppgitt",
-                        detail = cause.message,
-                        instance = URI.create("urn:fritak:json-mapping-error:$errorId")
-                )
-                call.respond(HttpStatusCode.BadRequest, problem)
-            }
-        }
-
-        exception<ConstraintViolationException> { cause ->
-            handleValidationError(call, cause)
-        }
-    }
-
     routing {
         authenticate {
-            fritakAGP(get(), get(), get(), get(), get(), get(), get())
+            fritakAGPRoutes(get(), get(), get(), get(), get(), get(), get())
+            altinnRoutes(get())
         }
+    }
+}
+
+private fun Application.configureCORSAccess(config: ApplicationConfig) {
+    install(CORS)
+    {
+        method(HttpMethod.Options)
+        method(HttpMethod.Post)
+        method(HttpMethod.Get)
+
+        when (config.getEnvironment()) {
+            AppEnv.PROD -> host("arbeidsgiver.nav.no", schemes = listOf("https"))
+            else -> anyHost()
+        }
+
+        allowCredentials = true
+        allowNonSimpleContentTypes = true
     }
 }

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/AltinnRettigheterRoute.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/AltinnRettigheterRoute.kt
@@ -1,0 +1,28 @@
+package no.nav.helse.fritakagp.web.api
+
+import io.ktor.application.*
+import io.ktor.http.*
+import io.ktor.response.*
+import io.ktor.routing.*
+import io.ktor.util.*
+import no.nav.helse.arbeidsgiver.integrasjoner.altinn.AltinnBrukteForLangTidException
+import no.nav.helse.arbeidsgiver.web.auth.AltinnOrganisationsRepository
+import no.nav.helse.fritakagp.web.hentIdentitetsnummerFraLoginToken
+
+@KtorExperimentalAPI
+fun Route.altinnRoutes(authRepo: AltinnOrganisationsRepository) {
+
+    route("/api/v1") {
+        route("/arbeidsgivere") {
+            get("/") {
+                val id = hentIdentitetsnummerFraLoginToken(application.environment.config, call.request)
+                try {
+                    val rettigheter = authRepo.hentOrgMedRettigheterForPerson(id)
+                    call.respond(rettigheter)
+                } catch (ae: AltinnBrukteForLangTidException) {
+                    call.respond(HttpStatusCode.ExpectationFailed, "Altinn brukte for lang tid på å svare, prøv igjen om litt")
+                }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/ApiExceptionHandling.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/ApiExceptionHandling.kt
@@ -1,0 +1,134 @@
+package no.nav.helse.fritakagp.web.api
+
+import com.fasterxml.jackson.databind.JsonMappingException
+import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
+import io.ktor.application.*
+import io.ktor.features.*
+import io.ktor.http.*
+import io.ktor.response.*
+import no.nav.helse.arbeidsgiver.web.validation.Problem
+import no.nav.helse.arbeidsgiver.web.validation.ValidationProblem
+import no.nav.helse.arbeidsgiver.web.validation.ValidationProblemDetail
+import no.nav.helse.fritakagp.web.dto.validation.getContextualMessage
+import org.slf4j.LoggerFactory
+import org.valiktor.ConstraintViolationException
+import java.lang.reflect.InvocationTargetException
+import java.net.URI
+import java.util.*
+import javax.ws.rs.ForbiddenException
+
+fun Application.configureExceptionHandling() {
+    install(StatusPages) {
+        val logger = LoggerFactory.getLogger("StatusPages")
+
+        suspend fun handleUnexpectedException(call: ApplicationCall, cause: Throwable) {
+            val errorId = UUID.randomUUID()
+            val userAgent = call.request.headers.get("User-Agent") ?: "Ukjent"
+            logger.error("Uventet feil, $errorId med useragent $userAgent", cause)
+            val problem = Problem(
+                type = URI.create("urn:fritak:uventet-feil"),
+                title = "Uventet feil",
+                detail = cause.message,
+                instance = URI.create("urn:fritak:uventent-feil:$errorId")
+            )
+            call.respond(HttpStatusCode.InternalServerError, problem)
+        }
+
+        suspend fun handleValidationError(call: ApplicationCall, cause: ConstraintViolationException) {
+            val problems = cause.constraintViolations.map {
+                ValidationProblemDetail(it.constraint.name, it.getContextualMessage(), it.property, it.value)
+            }.toSet()
+
+            problems
+                .filter {
+                    it.propertyPath.contains("perioder")
+                }
+                .forEach {
+                    logger.warn("Invalid ${it.propertyPath}: ${it.invalidValue} (${it.message})")
+                }
+
+            call.respond(HttpStatusCode.UnprocessableEntity, ValidationProblem(problems))
+        }
+
+        exception<InvocationTargetException> { cause ->
+            when (cause.targetException) {
+                is ConstraintViolationException -> handleValidationError(
+                    call,
+                    cause.targetException as ConstraintViolationException
+                )
+                else -> handleUnexpectedException(call, cause)
+            }
+        }
+
+        exception<ForbiddenException> {
+            call.respond(
+                HttpStatusCode.Forbidden,
+                Problem(URI.create("urn:fritak:forbidden"), "Ingen tilgang", HttpStatusCode.Forbidden.value)
+            )
+        }
+
+        exception<Throwable> { cause ->
+            handleUnexpectedException(call, cause)
+        }
+
+        exception<ParameterConversionException> { cause ->
+            call.respond(
+                HttpStatusCode.BadRequest,
+                ValidationProblem(
+                    setOf(
+                        ValidationProblemDetail(
+                            "ParameterConversion",
+                            "Parameteret kunne ikke  konverteres til ${cause.type}",
+                            cause.parameterName,
+                            null
+                        )
+                    )
+                )
+            )
+            logger.warn("${cause.parameterName} kunne ikke konverteres")
+        }
+
+        exception<MissingKotlinParameterException> { cause ->
+            val userAgent = call.request.headers.get("User-Agent") ?: "Ukjent"
+            call.respond(
+                HttpStatusCode.BadRequest,
+                ValidationProblem(
+                    setOf(
+                        ValidationProblemDetail(
+                            "NotNull",
+                            "Det angitte feltet er påkrevd",
+                            cause.path.filter { it.fieldName != null }.joinToString(".") {
+                                it.fieldName
+                            },
+                            "null"
+                        )
+                    )
+                )
+            )
+            logger.warn("Feil med validering av ${cause.parameter.name ?: "Ukjent"} for ${userAgent}: ${cause.message}")
+        }
+
+        exception<JsonMappingException> { cause ->
+            if (cause.cause is ConstraintViolationException) {
+                handleValidationError(call, cause.cause as ConstraintViolationException)
+            } else {
+                val errorId = UUID.randomUUID()
+                val userAgent = call.request.headers.get("User-Agent") ?: "Ukjent"
+                val locale = call.request.headers.get("Accept-Language") ?: "Ukjent"
+                logger.warn("$errorId : $userAgent : $locale", cause)
+                val problem = Problem(
+                    status = HttpStatusCode.BadRequest.value,
+                    title = "Feil ved prosessering av JSON-dataene som ble oppgitt",
+                    detail = cause.message,
+                    instance = URI.create("urn:fritak:json-mapping-error:$errorId")
+                )
+                call.respond(HttpStatusCode.BadRequest, problem)
+            }
+        }
+
+        exception<ConstraintViolationException> { cause ->
+            handleValidationError(call, cause)
+        }
+    }
+
+}

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/ApiExceptionHandling.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/ApiExceptionHandling.kt
@@ -23,7 +23,8 @@ fun Application.configureExceptionHandling() {
 
         suspend fun handleUnexpectedException(call: ApplicationCall, cause: Throwable) {
             val errorId = UUID.randomUUID()
-            val userAgent = call.request.headers.get("User-Agent") ?: "Ukjent"
+
+            val userAgent = call.request.headers.get(HttpHeaders.UserAgent) ?: "Ukjent"
             logger.error("Uventet feil, $errorId med useragent $userAgent", cause)
             val problem = Problem(
                 type = URI.create("urn:fritak:uventet-feil"),
@@ -89,7 +90,7 @@ fun Application.configureExceptionHandling() {
         }
 
         exception<MissingKotlinParameterException> { cause ->
-            val userAgent = call.request.headers.get("User-Agent") ?: "Ukjent"
+            val userAgent = call.request.headers.get(HttpHeaders.UserAgent) ?: "Ukjent"
             call.respond(
                 HttpStatusCode.BadRequest,
                 ValidationProblem(
@@ -113,8 +114,8 @@ fun Application.configureExceptionHandling() {
                 handleValidationError(call, cause.cause as ConstraintViolationException)
             } else {
                 val errorId = UUID.randomUUID()
-                val userAgent = call.request.headers.get("User-Agent") ?: "Ukjent"
-                val locale = call.request.headers.get("Accept-Language") ?: "Ukjent"
+                val userAgent = call.request.headers.get(HttpHeaders.UserAgent) ?: "Ukjent"
+                val locale = call.request.headers.get(HttpHeaders.AcceptLanguage) ?: "Ukjent"
                 logger.warn("$errorId : $userAgent : $locale", cause)
                 val problem = Problem(
                     status = HttpStatusCode.BadRequest.value,

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/FritakAGPRoute.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/FritakAGPRoute.kt
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory
 import javax.sql.DataSource
 
 @KtorExperimentalAPI
-fun Route.fritakAGP(
+fun Route.fritakAGPRoutes(
         datasource: DataSource,
         gravidRepo: GravidSoeknadRepository,
         kroniskRepo: KroniskSoeknadRepository,

--- a/src/main/resources/altinn-mock/organisasjoner-med-rettighet.json
+++ b/src/main/resources/altinn-mock/organisasjoner-med-rettighet.json
@@ -1,0 +1,32 @@
+[
+  {
+    "Name": "HØNEFOSS OG ØLEN",
+    "Type": "Enterprise",
+    "OrganizationNumber": "910020102",
+    "OrganizationForm": "AS",
+    "Status": "Active"
+  },
+  {
+    "Name": "JØA OG SEL",
+    "Type": "Business",
+    "OrganizationNumber": "910098896",
+    "ParentOrganizationNumber": "911366940",
+    "OrganizationForm": "BEDR",
+    "Status": "Active"
+  },
+  {
+    "Name": "ELTRODE AS",
+    "Type": "Business",
+    "ParentOrganizationNumber": "917346380",
+    "OrganizationNumber": "917404437",
+    "OrganizationForm": "BEDR",
+    "Status": "Active"
+  },
+  {
+    "Name": "STADLANDET OG SINGSÅS",
+    "Type": "Enterprise",
+    "OrganizationNumber": "911366940",
+    "OrganizationForm": "AS",
+    "Status": "Active"
+  }
+]

--- a/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/ArbeidsgivereHTTPTests.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/ArbeidsgivereHTTPTests.kt
@@ -1,0 +1,36 @@
+package no.nav.helse.slowtests.systemtests.api
+
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.*
+import no.nav.helse.KroniskTestData
+import no.nav.helse.arbeidsgiver.integrasjoner.altinn.AltinnOrganisasjon
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+
+class ArbeidsgivereHTTPTests : SystemTestBase() {
+    private val arbeidsgivereUrl = "/api/v1/arbeidsgivere"
+
+
+    @Test
+    fun `Skal returnere 401 når man ikke er logget inn`() = suspendableTest {
+        val response = httpClient.get<HttpResponse> {
+            appUrl(arbeidsgivereUrl)
+            contentType(ContentType.Application.Json)
+        }
+
+        Assertions.assertThat(response.status).isEqualTo(HttpStatusCode.Unauthorized)
+    }
+
+    @Test
+    fun `Skal returnere liste av arbeidsgivere når man er logget inn`() = suspendableTest {
+        val response = httpClient.get<Set<AltinnOrganisasjon>> {
+            appUrl(arbeidsgivereUrl)
+            contentType(ContentType.Application.Json)
+            loggedInAs("123456789")
+            body = KroniskTestData.kroniskSoknadMedFil
+        }
+
+        Assertions.assertThat(response.size).isGreaterThan(0)
+    }
+}


### PR DESCRIPTION
Legger til et nytt endepunkt som server frontenden den innloggede brukerens rettigheter fra Altinn.

Foreløpig er det ingen konkret implementasjon mot Altinn, siden vi ikke har bestemt hva kilden skal være. PRen bruker interfacet fra fellesbiblioteket vårt, og der ligger også den konkrete klienten vi bruker senere. Til kildespørsmålet er avgjort får vi en hengeoppgave med å  konfigurere den opp og sette opp tilganger for klienten.

Ryddet også litt i API;
 - Dro ut exceptionhandling på API nivået til en egen metode for å gjøre det mer tydelig hvor dette gjøres
 - Slettet ubrukte features (Location, DataConversion)
 - Dro ut mocks fra KoinProfiles til egen fil