### PR TITLE
Bruker navn i stedet for fnr i altinn-kvittering

### DIFF
--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/GravidKrav.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/GravidKrav.kt
@@ -19,5 +19,7 @@ data class GravidKrav(
     var journalpostId: String? = null,
 
     var oppgaveId: String? = null,
-    var virksomhetsnavn: String? = null
+    var virksomhetsnavn: String? = null,
+    // Må være null for tidligere verdier er lagret med null
+    val sendtAvNavn: String? = null
 ) : SimpleJsonbEntity

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/GravidKrav.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/GravidKrav.kt
@@ -7,7 +7,7 @@ import java.util.*
 data class GravidKrav(
     override val id: UUID = UUID.randomUUID(),
     val opprettet: LocalDateTime = LocalDateTime.now(),
-    var sendtAv: String,
+    val sendtAv: String,
 
     val virksomhetsnummer: String,
     val identitetsnummer: String,
@@ -21,5 +21,5 @@ data class GravidKrav(
     var oppgaveId: String? = null,
     var virksomhetsnavn: String? = null,
     // Må være null for tidligere verdier er lagret med null
-    val sendtAvNavn: String? = null
+    var sendtAvNavn: String? = null
 ) : SimpleJsonbEntity

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/GravidSoeknad.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/GravidSoeknad.kt
@@ -6,30 +6,32 @@ import java.time.LocalDateTime
 import java.util.*
 
 data class GravidSoeknad(
-        override val id: UUID = UUID.randomUUID(),
-        val opprettet: LocalDateTime = LocalDateTime.now(),
+    override val id: UUID = UUID.randomUUID(),
+    val opprettet: LocalDateTime = LocalDateTime.now(),
 
-        val virksomhetsnummer: String,
-        val identitetsnummer: String,
-        val tilrettelegge: Boolean,
-        val tiltak: List<Tiltak>? = null,
-        val tiltakBeskrivelse: String? = null,
-        val omplassering: Omplassering?,
-        val omplasseringAarsak: OmplasseringAarsak? = null,
-        var sendtAv: String,
-        val termindato: LocalDate?,
-        val harVedlegg: Boolean = false,
-        var virksomhetsnavn: String? = null,
+    val virksomhetsnummer: String,
+    val identitetsnummer: String,
+    val tilrettelegge: Boolean,
+    val tiltak: List<Tiltak>? = null,
+    val tiltakBeskrivelse: String? = null,
+    val omplassering: Omplassering?,
+    val omplasseringAarsak: OmplasseringAarsak? = null,
+    var sendtAv: String,
+    val termindato: LocalDate?,
+    val harVedlegg: Boolean = false,
+    var virksomhetsnavn: String? = null,
 
-        /**
+    /**
      * ID fra joark etter arkivering
      */
-        var journalpostId: String? = null,
+    var journalpostId: String? = null,
 
-        /**
+    /**
      * ID fra oppgave etter opprettelse av oppgave
      */
-        var oppgaveId: String? = null
+    var oppgaveId: String? = null,
+    // Må være null for tidligere verdier er lagret med null
+    val sendtAvNavn: String? = null
 ) : SimpleJsonbEntity
 
 enum class Omplassering(val beskrivelse: String) {

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/GravidSoeknad.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/GravidSoeknad.kt
@@ -16,7 +16,7 @@ data class GravidSoeknad(
     val tiltakBeskrivelse: String? = null,
     val omplassering: Omplassering?,
     val omplasseringAarsak: OmplasseringAarsak? = null,
-    var sendtAv: String,
+    val sendtAv: String,
     val termindato: LocalDate?,
     val harVedlegg: Boolean = false,
     var virksomhetsnavn: String? = null,
@@ -31,7 +31,7 @@ data class GravidSoeknad(
      */
     var oppgaveId: String? = null,
     // Må være null for tidligere verdier er lagret med null
-    val sendtAvNavn: String? = null
+    var sendtAvNavn: String? = null
 ) : SimpleJsonbEntity
 
 enum class Omplassering(val beskrivelse: String) {

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskKrav.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskKrav.kt
@@ -19,5 +19,7 @@ data class KroniskKrav(
     var journalpostId: String? = null,
 
     var oppgaveId: String? = null,
-    var virksomhetsnavn: String? = null
+    var virksomhetsnavn: String? = null,
+    // Må være null for tidligere verdier er lagret med null
+    val sendtAvNavn: String? = null
 ) : SimpleJsonbEntity

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskKrav.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskKrav.kt
@@ -7,7 +7,7 @@ import java.util.*
 data class KroniskKrav(
     override val id: UUID = UUID.randomUUID(),
     val opprettet: LocalDateTime = LocalDateTime.now(),
-    var sendtAv: String,
+    val sendtAv: String,
 
     val virksomhetsnummer: String,
     val identitetsnummer: String,
@@ -21,5 +21,5 @@ data class KroniskKrav(
     var oppgaveId: String? = null,
     var virksomhetsnavn: String? = null,
     // Må være null for tidligere verdier er lagret med null
-    val sendtAvNavn: String? = null
+    var sendtAvNavn: String? = null
 ) : SimpleJsonbEntity

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskSoeknad.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskSoeknad.kt
@@ -15,7 +15,7 @@ data class KroniskSoeknad(
     val paakjenningstyper: Set<PaakjenningsType>,
     val paakjenningBeskrivelse: String? = null,
     val fravaer: Set<FravaerData>,
-    val antallPerioder : Int,
+    val antallPerioder: Int,
     val bekreftet: Boolean,
     val harVedlegg: Boolean = false,
 
@@ -23,14 +23,16 @@ data class KroniskSoeknad(
     var virksomhetsnavn: String? = null,
 
     /**
-         * ID fra joark etter arkivering
-         */
-        var journalpostId: String? = null,
+     * ID fra joark etter arkivering
+     */
+    var journalpostId: String? = null,
 
     /**
-         * ID fra oppgave etter opprettelse av oppgave
-         */
-        var oppgaveId: String? = null
+     * ID fra oppgave etter opprettelse av oppgave
+     */
+    var oppgaveId: String? = null,
+    // Må være null for tidligere verdier er lagret med null
+    val sendtAvNavn: String? = null
 ): SimpleJsonbEntity
 
 data class FravaerData (

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskSoeknad.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskSoeknad.kt
@@ -19,7 +19,7 @@ data class KroniskSoeknad(
     val bekreftet: Boolean,
     val harVedlegg: Boolean = false,
 
-    var sendtAv: String,
+    val sendtAv: String,
     var virksomhetsnavn: String? = null,
 
     /**
@@ -32,7 +32,7 @@ data class KroniskSoeknad(
      */
     var oppgaveId: String? = null,
     // Må være null for tidligere verdier er lagret med null
-    val sendtAvNavn: String? = null
+    var sendtAvNavn: String? = null
 ): SimpleJsonbEntity
 
 data class FravaerData (

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/brukernotifikasjon/BrukernotifikasjonProcessor.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/brukernotifikasjon/BrukernotifikasjonProcessor.kt
@@ -16,8 +16,6 @@ import no.nav.helse.fritakagp.integration.kafka.BrukernotifikasjonBeskjedSender
 import java.net.URL
 import java.time.LocalDateTime
 import java.time.ZoneId
-import java.time.ZoneOffset
-import java.time.ZonedDateTime
 import java.util.*
 
 class BrukernotifikasjonProcessor(

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/GravidKravKvittering.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/GravidKravKvittering.kt
@@ -46,7 +46,6 @@ class GravidKravAltinnKvitteringSender(
 
     fun mapKvitteringTilInsertCorrespondence(kvittering: GravidKrav): InsertCorrespondenceV2 {
         val dateTimeFormatterMedKl = DateTimeFormatter.ofPattern("dd.MM.yyyy 'kl.' HH:mm")
-        val dateFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
         val tittel = "Kvittering for mottatt refusjonskrav fra arbeidsgiverperioden grunnet graviditet"
 
         val innhold = """

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/GravidKravKvittering.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/GravidKravKvittering.kt
@@ -66,7 +66,7 @@ class GravidKravAltinnKvitteringSender(
                 <li>Fødselsnummer: ${kvittering.identitetsnummer}</li>
                 <li>Dokumentasjon vedlagt: ${if (kvittering.harVedlegg) "Ja" else "Nei"}</li>                      
                 <li>Mottatt: ${kvittering.opprettet.format(dateTimeFormatterMedKl)}</li>
-                <li>Innrapportert av: ${kvittering.sendtAv}</li>
+                <li>Innrapportert av: ${kvittering.sendtAvNavn}</li>
                 <li>Perioder: </li>
                 <ul> ${lagrePerioder(kvittering.perioder)}</ul>
             </ul>

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/soeknad/GravidSoeknadKvittering.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/soeknad/GravidSoeknadKvittering.kt
@@ -69,7 +69,7 @@ class GravidSoeknadAltinnKvitteringSender(
                 <li>Tiltak:${ lagreTiltak(kvittering.tiltak) } </li>
                 <li>Forsøkt omplassering: ${lagreOmplasseringStr(kvittering)}</li>               
                 <li>Mottatt: ${kvittering.opprettet.format(dateTimeFormatterMedKl)}</li>
-                <li>Innrapportert av: ${kvittering.sendtAv}</li>
+                <li>Innrapportert av: ${kvittering.sendtAvNavn}</li>
             </ul>
                </div>
            </body>

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/soeknad/GravidSoeknadProcessor.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/soeknad/GravidSoeknadProcessor.kt
@@ -2,9 +2,6 @@ package no.nav.helse.fritakagp.processing.gravid.soeknad
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
-import io.ktor.client.call.*
-import io.ktor.client.features.*
-import io.ktor.util.*
 import kotlinx.coroutines.runBlocking
 import no.nav.helse.arbeidsgiver.bakgrunnsjobb.Bakgrunnsjobb
 import no.nav.helse.arbeidsgiver.bakgrunnsjobb.BakgrunnsjobbProsesserer

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravKvittering.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravKvittering.kt
@@ -65,7 +65,7 @@ class KroniskKravAltinnKvitteringSender(
                 <li>Fødselsnummer: ${kvittering.identitetsnummer} </li>
                 <li>Dokumentasjon vedlagt: ${if (kvittering.harVedlegg) "Ja" else "Nei"} </li>
                 <li>Mottatt:  ${kvittering.opprettet.format(dateTimeFormatterMedKl)}  </li>  
-                <li>Innrapportert av: ${kvittering.sendtAv}</li>
+                <li>Innrapportert av: ${kvittering.sendtAvNavn}</li>
                 <li>Perioder: </li>
                 <ul> ${lagrePerioder(kvittering.perioder)}</ul>
             </ul>

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/soeknad/KroniskSoeknadKvittering.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/soeknad/KroniskSoeknadKvittering.kt
@@ -64,7 +64,7 @@ class KroniskSoeknadAltinnKvitteringSender(
                 <li>Fødselsnummer: ${kvittering.identitetsnummer} </li>
                 <li>Dokumentasjon vedlagt: ${if (kvittering.harVedlegg) "Ja" else "Nei"} </li>
                 <li>Mottatt:  ${kvittering.opprettet.format(dateTimeFormatterMedKl)}  </li>  
-                <li>Innrapportert av: ${kvittering.sendtAv}</li>        
+                <li>Innrapportert av: ${kvittering.sendtAvNavn}</li>
             </ul>
                </div>
            </body>

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/GravidRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/GravidRoutes.kt
@@ -58,7 +58,7 @@ fun Route.gravidRoutes(
                 if (form == null || form.identitetsnummer != innloggetFnr) {
                     call.respond(HttpStatusCode.NotFound)
                 } else {
-                    form.sendtAv = pdlService.finnNavn(innloggetFnr)
+                    form.sendtAvNavn = pdlService.finnNavn(innloggetFnr)
                     call.respond(HttpStatusCode.OK, form)
                 }
             }
@@ -101,7 +101,7 @@ fun Route.gravidRoutes(
                 if (form == null || form.identitetsnummer != innloggetFnr) {
                     call.respond(HttpStatusCode.NotFound)
                 } else {
-                    form.sendtAv = pdlService.finnNavn(innloggetFnr)
+                    form.sendtAvNavn = pdlService.finnNavn(innloggetFnr)
                     call.respond(HttpStatusCode.OK, form)
                 }
             }
@@ -144,7 +144,7 @@ fun Route.gravidRoutes(
 fun periodValErrs(it: ConstraintViolation) : List<ValidationProblemDetail> {
     val valErrs = mutableListOf<ValidationProblemDetail>()
     if (it.property == "perioder") {
-        (it.value as Set<*>).forEach { p ->
+        (it.value as Set<*>).forEach { _ ->
             valErrs.add(
                 ValidationProblemDetail(
                     it.constraint.name,

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/GravidRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/GravidRoutes.kt
@@ -8,7 +8,6 @@ import io.ktor.response.*
 import io.ktor.routing.*
 import no.nav.helse.arbeidsgiver.bakgrunnsjobb.BakgrunnsjobbService
 import no.nav.helse.arbeidsgiver.integrasjoner.aareg.AaregArbeidsforholdClient
-import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlClient
 import no.nav.helse.arbeidsgiver.web.auth.AltinnAuthorizer
 import no.nav.helse.fritakagp.GravidKravMetrics
 import no.nav.helse.fritakagp.GravidSoeknadMetrics
@@ -71,7 +70,8 @@ fun Route.gravidRoutes(
                 val isVirksomhet = breegClient.erVirksomhet(request.virksomhetsnummer)
                 request.validate(isVirksomhet)
 
-                val soeknad = request.toDomain(innloggetFnr)
+                val sendtAvNavn = pdlService.finnNavn(innloggetFnr)
+                val soeknad = request.toDomain(innloggetFnr, sendtAvNavn)
 
                 processDocumentForGCPStorage(request.dokumentasjon, virusScanner, bucket, soeknad.id)
 
@@ -115,12 +115,9 @@ fun Route.gravidRoutes(
 
                 request.validate(arbeidsforhold)
 
-                val krav = request.toDomain(
-                    hentIdentitetsnummerFraLoginToken(
-                        application.environment.config,
-                        call.request
-                    )
-                )
+                val innloggetFnr = hentIdentitetsnummerFraLoginToken(application.environment.config, call.request)
+                val sendtAvNavn = pdlService.finnNavn(innloggetFnr)
+                val krav = request.toDomain(innloggetFnr, sendtAvNavn)
                 belopBeregning.beregnBeløpGravid(krav)
                 processDocumentForGCPStorage(request.dokumentasjon, virusScanner, bucket, krav.id)
 

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/KroniskRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/KroniskRoutes.kt
@@ -51,7 +51,7 @@ fun Route.kroniskRoutes(
                 if (form == null || form.identitetsnummer != innloggetFnr) {
                     call.respond(HttpStatusCode.NotFound)
                 } else {
-                    form.sendtAv = pdlService.finnNavn(innloggetFnr)
+                    form.sendtAvNavn = form.sendtAvNavn ?: pdlService.finnNavn(innloggetFnr)
                     call.respond(HttpStatusCode.OK, form)
                 }
             }
@@ -93,7 +93,7 @@ fun Route.kroniskRoutes(
                 if (form == null || form.identitetsnummer != innloggetFnr) {
                     call.respond(HttpStatusCode.NotFound)
                 } else {
-                    form.sendtAv = pdlService.finnNavn(innloggetFnr)
+                    form.sendtAvNavn = form.sendtAvNavn ?: pdlService.finnNavn(innloggetFnr)
                     call.respond(HttpStatusCode.OK, form)
                 }
             }

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/KroniskRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/KroniskRoutes.kt
@@ -63,7 +63,8 @@ fun Route.kroniskRoutes(
                 request.validate(isVirksomhet)
                 val innloggetFnr = hentIdentitetsnummerFraLoginToken(application.environment.config, call.request)
 
-                val soeknad = request.toDomain(innloggetFnr)
+                val sendtAvNavn = pdlService.finnNavn(innloggetFnr)
+                val soeknad = request.toDomain(sendtAvNavn, innloggetFnr)
                 processDocumentForGCPStorage(request.dokumentasjon, virusScanner, bucket, soeknad.id)
 
                 datasource.connection.use { connection ->
@@ -106,8 +107,11 @@ fun Route.kroniskRoutes(
 
                 request.validate(arbeidsforhold)
 
-                val krav =
-                    request.toDomain(hentIdentitetsnummerFraLoginToken(application.environment.config, call.request))
+                val innloggetFnr = hentIdentitetsnummerFraLoginToken(application.environment.config, call.request)
+                val sendtAvNavn = pdlService.finnNavn(innloggetFnr)
+
+                val krav = request.toDomain(innloggetFnr, sendtAvNavn)
+
                 belopBeregning.beregnBeløpKronisk(krav)
                 processDocumentForGCPStorage(request.dokumentasjon, virusScanner, bucket, krav.id)
 

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/resreq/GravidResReq.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/resreq/GravidResReq.kt
@@ -52,10 +52,11 @@ data class GravidSoknadRequest(
         }
     }
 
-    fun toDomain(sendtAv: String) = GravidSoeknad(
+    fun toDomain(sendtAv: String, sendtAvNavn: String) = GravidSoeknad(
         virksomhetsnummer = virksomhetsnummer,
         identitetsnummer = identitetsnummer,
         sendtAv = sendtAv,
+        sendtAvNavn = sendtAvNavn,
         termindato = termindato,
         omplassering = omplassering,
         omplasseringAarsak = omplasseringAarsak,
@@ -98,11 +99,12 @@ data class GravidKravRequest(
         }
     }
 
-    fun toDomain(sendtAv: String) = GravidKrav(
+    fun toDomain(sendtAv: String, sendtAvNavn: String) = GravidKrav(
         identitetsnummer = identitetsnummer,
         virksomhetsnummer = virksomhetsnummer,
         perioder = perioder,
         sendtAv = sendtAv,
+        sendtAvNavn = sendtAvNavn,
         harVedlegg = !dokumentasjon.isNullOrEmpty(),
         kontrollDager = kontrollDager,
         antallDager = antallDager

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/resreq/KroniskResReq.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/resreq/KroniskResReq.kt
@@ -5,7 +5,6 @@ import no.nav.helse.arbeidsgiver.web.validation.isValidIdentitetsnummer
 import no.nav.helse.arbeidsgiver.web.validation.isValidOrganisasjonsnummer
 import no.nav.helse.fritakagp.domain.*
 import no.nav.helse.fritakagp.web.api.resreq.validation.*
-import no.nav.helse.fritakagp.web.dto.validation.*
 import org.valiktor.functions.*
 import org.valiktor.validate
 
@@ -53,10 +52,11 @@ data class KroniskSoknadRequest(
         }
     }
     
-    fun toDomain(sendtAv: String) = KroniskSoeknad(
+    fun toDomain(sendtAv: String, sendtAvNavn: String) = KroniskSoeknad(
         virksomhetsnummer = virksomhetsnummer,
         identitetsnummer = identitetsnummer,
         sendtAv = sendtAv,
+        sendtAvNavn = sendtAvNavn,
         arbeidstyper = arbeidstyper,
         antallPerioder = antallPerioder,
         paakjenningstyper = paakjenningstyper,
@@ -99,11 +99,12 @@ data class KroniskKravRequest(
         }
     }
     
-    fun toDomain(sendtAv: String) = KroniskKrav(
+    fun toDomain(sendtAv: String, sendtAvNavn: String) = KroniskKrav(
         identitetsnummer = identitetsnummer,
         virksomhetsnummer = virksomhetsnummer,
         perioder = perioder,
         sendtAv = sendtAv,
+        sendtAvNavn = sendtAvNavn,
         harVedlegg = !dokumentasjon.isNullOrEmpty(),
         kontrollDager = kontrollDager,
         antallDager = antallDager

--- a/src/test/kotlin/no/nav/helse/GravidTestData.kt
+++ b/src/test/kotlin/no/nav/helse/GravidTestData.kt
@@ -16,7 +16,6 @@ object GravidTestData {
     val soeknadGravid = GravidSoeknad(
         virksomhetsnummer = validOrgNr,
         identitetsnummer = validIdentitetsnummer,
-        termindato = LocalDate.now().plusDays(25),
         tilrettelegge = true,
         tiltak = listOf(Tiltak.HJEMMEKONTOR, Tiltak.ANNET),
         tiltakBeskrivelse = """Vi prøvde både det ene og det andre og det første kanskje virka litt men muligens and the andre ikke var så på stell men akk ja sånn lorem
@@ -37,7 +36,9 @@ aąbcćdeęfghijlłmnńoóprsśtuwź
         """.trimMargin(),
         omplassering = Omplassering.IKKE_MULIG,
         omplasseringAarsak = OmplasseringAarsak.HELSETILSTANDEN,
-        sendtAv = validName
+        sendtAv = validName,
+        termindato = LocalDate.now().plusDays(25),
+        sendtAvNavn = validName
     )
 
     val fullValidSoeknadRequest = GravidSoknadRequest(
@@ -164,7 +165,9 @@ aąbcćdeęfghijlłmnńoóprsśtuwź
 
 
     val gravidKrav = GravidKrav(
+        sendtAv = validName,
         virksomhetsnummer = validOrgNr,
+
         identitetsnummer = validIdentitetsnummer,
 
         perioder = listOf(Arbeidsgiverperiode(
@@ -173,10 +176,9 @@ aąbcćdeęfghijlłmnńoóprsśtuwź
             5,
             månedsinntekt = 2590.8
         )),
-
-        sendtAv = validName,
         kontrollDager = null,
-        antallDager = 4
+        antallDager = 4,
+        sendtAvNavn = validName
     )
 
     val gravidOpprettOppgaveResponse = OpprettOppgaveResponse(

--- a/src/test/kotlin/no/nav/helse/GravidTestData.kt
+++ b/src/test/kotlin/no/nav/helse/GravidTestData.kt
@@ -36,7 +36,7 @@ aąbcćdeęfghijlłmnńoóprsśtuwź
         """.trimMargin(),
         omplassering = Omplassering.IKKE_MULIG,
         omplasseringAarsak = OmplasseringAarsak.HELSETILSTANDEN,
-        sendtAv = validName,
+        sendtAv = validIdentitetsnummer,
         termindato = LocalDate.now().plusDays(25),
         sendtAvNavn = validName
     )
@@ -165,7 +165,7 @@ aąbcćdeęfghijlłmnńoóprsśtuwź
 
 
     val gravidKrav = GravidKrav(
-        sendtAv = validName,
+        sendtAv = validIdentitetsnummer,
         virksomhetsnummer = validOrgNr,
 
         identitetsnummer = validIdentitetsnummer,

--- a/src/test/kotlin/no/nav/helse/KroniskTestData.kt
+++ b/src/test/kotlin/no/nav/helse/KroniskTestData.kt
@@ -25,7 +25,7 @@ object KroniskTestData {
         fravaer = generateFravaersdata(),
         antallPerioder = antallPerioder,
         bekreftet = true,
-        sendtAv = validName,
+        sendtAv = validIdentitetsnummer,
         sendtAvNavn = validName
     )
 
@@ -101,7 +101,7 @@ object KroniskTestData {
     )
 
     val kroniskKrav = KroniskKrav(
-        sendtAv = validName,
+        sendtAv = validIdentitetsnummer,
         virksomhetsnummer = validOrgNr,
         identitetsnummer = validIdentitetsnummer,
         perioder = listOf(Arbeidsgiverperiode(

--- a/src/test/kotlin/no/nav/helse/KroniskTestData.kt
+++ b/src/test/kotlin/no/nav/helse/KroniskTestData.kt
@@ -20,12 +20,13 @@ object KroniskTestData {
         virksomhetsnummer = validOrgNr,
         identitetsnummer = validIdentitetsnummer,
         arbeidstyper = setOf(ArbeidsType.KREVENDE, ArbeidsType.MODERAT),
-        bekreftet = true,
-        antallPerioder = antallPerioder,
-        fravaer = generateFravaersdata(),
         paakjenningstyper = setOf(PaakjenningsType.ALLERGENER, PaakjenningsType.TUNGE),
         paakjenningBeskrivelse = "Beskrivelse",
-        sendtAv = validName
+        fravaer = generateFravaersdata(),
+        antallPerioder = antallPerioder,
+        bekreftet = true,
+        sendtAv = validName,
+        sendtAvNavn = validName
     )
 
     val fullValidRequest = KroniskSoknadRequest(
@@ -100,6 +101,7 @@ object KroniskTestData {
     )
 
     val kroniskKrav = KroniskKrav(
+        sendtAv = validName,
         virksomhetsnummer = validOrgNr,
         identitetsnummer = validIdentitetsnummer,
         perioder = listOf(Arbeidsgiverperiode(
@@ -108,9 +110,9 @@ object KroniskTestData {
             5,
             månedsinntekt = 2590.8
         )),
-        sendtAv = validName,
         kontrollDager = null,
-        antallDager = 4
+        antallDager = 4,
+        sendtAvNavn = validName
     )
 
     val kroniskOpprettOppgaveResponse = OpprettOppgaveResponse(

--- a/src/test/kotlin/no/nav/helse/fritakagp/web/api/resreq/GravidKravRequestTest.kt
+++ b/src/test/kotlin/no/nav/helse/fritakagp/web/api/resreq/GravidKravRequestTest.kt
@@ -52,8 +52,8 @@ class GravidKravRequestTest{
 
     @Test
     internal fun `mapping til domenemodell tar med harVedleggflagg`() {
-        assertThat(GravidTestData.gravidKravRequestMedFil.toDomain("123").harVedlegg).isTrue
-        assertThat(GravidTestData.gravidKravRequestValid.toDomain("123").harVedlegg).isFalse
+        assertThat(GravidTestData.gravidKravRequestMedFil.toDomain("123", "Ola M Avsender").harVedlegg).isTrue
+        assertThat(GravidTestData.gravidKravRequestValid.toDomain("123", "Ola M Avsender").harVedlegg).isFalse
 
     }
 
@@ -83,7 +83,7 @@ class GravidKravRequestTest{
         every { grunnbeløpClient.hentGrunnbeløp().grunnbeløp } returns 106399
 
         val belopBeregning =  BeløpBeregning(grunnbeløpClient)
-        val krav = GravidTestData.gravidKravRequestValid.toDomain("123")
+        val krav = GravidTestData.gravidKravRequestValid.toDomain("123", "Ola M Avsender")
         belopBeregning.beregnBeløpGravid(krav)
 
         assertThat(krav.perioder.first().dagsats).isEqualTo(7772.4)
@@ -96,7 +96,7 @@ class GravidKravRequestTest{
         every { grunnbeløpClient.hentGrunnbeløp().grunnbeløp } returns 106399
 
         val belopBeregning =  BeløpBeregning(grunnbeløpClient)
-        val krav = GravidTestData.gravidKravRequestWithWrongDecimal.toDomain("123")
+        val krav = GravidTestData.gravidKravRequestWithWrongDecimal.toDomain("123", "Ola M Avsender")
         belopBeregning.beregnBeløpGravid(krav)
 
         assertThat(krav.perioder.first().belop).isEqualTo(2848.6)

--- a/src/test/kotlin/no/nav/helse/fritakagp/web/api/resreq/GravidSoknadRequestTest.kt
+++ b/src/test/kotlin/no/nav/helse/fritakagp/web/api/resreq/GravidSoknadRequestTest.kt
@@ -63,8 +63,8 @@ class GravidSoknadRequestTest {
 
     @Test
     internal fun `mapping til domenemodell tar med harVedleggflagg`() {
-        Assertions.assertThat(GravidTestData.gravidSoknadMedFil.toDomain("123").harVedlegg).isTrue()
-        Assertions.assertThat(GravidTestData.fullValidSoeknadRequest.toDomain("123").harVedlegg).isFalse()
+        Assertions.assertThat(GravidTestData.gravidSoknadMedFil.toDomain("123", "Ola M Avsender").harVedlegg).isTrue()
+        Assertions.assertThat(GravidTestData.fullValidSoeknadRequest.toDomain("123", "Ola M Avsender").harVedlegg).isFalse()
     }
 
     @Test

--- a/src/test/kotlin/no/nav/helse/fritakagp/web/api/resreq/KroniskKravRequestTest.kt
+++ b/src/test/kotlin/no/nav/helse/fritakagp/web/api/resreq/KroniskKravRequestTest.kt
@@ -32,8 +32,8 @@ class KroniskKravRequestTest{
 
     @Test
     internal fun `mapping til domenemodell tar med harVedleggflagg`() {
-        Assertions.assertThat(KroniskTestData.kroniskKravRequestMedFil.toDomain("123").harVedlegg).isTrue
-        Assertions.assertThat(KroniskTestData.kroniskKravRequestValid.toDomain("123").harVedlegg).isFalse
+        Assertions.assertThat(KroniskTestData.kroniskKravRequestMedFil.toDomain("123", "Ola M Avsender").harVedlegg).isTrue
+        Assertions.assertThat(KroniskTestData.kroniskKravRequestValid.toDomain("123", "Ola M Avsender").harVedlegg).isFalse
     }
 
     @Test

--- a/src/test/kotlin/no/nav/helse/fritakagp/web/api/resreq/KroniskSoknadRequestTest.kt
+++ b/src/test/kotlin/no/nav/helse/fritakagp/web/api/resreq/KroniskSoknadRequestTest.kt
@@ -33,8 +33,8 @@ internal class KroniskSoknadRequestTest {
 
     @Test
     internal fun `mapping til domenemodell tar med harVedleggflagg`() {
-        Assertions.assertThat(KroniskTestData.kroniskSoknadMedFil.toDomain("123").harVedlegg).isTrue()
-        Assertions.assertThat(KroniskTestData.fullValidRequest.toDomain("123").harVedlegg).isFalse()
+        Assertions.assertThat(KroniskTestData.kroniskSoknadMedFil.toDomain("123", "Ola M Avsender").harVedlegg).isTrue()
+        Assertions.assertThat(KroniskTestData.fullValidRequest.toDomain("123", "Ola M Avsender").harVedlegg).isFalse()
     }
 
 

--- a/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/GravidSoeknadHTTPTests.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/GravidSoeknadHTTPTests.kt
@@ -7,7 +7,6 @@ import io.ktor.http.*
 import no.nav.helse.GravidTestData
 import no.nav.helse.fritakagp.db.GravidSoeknadRepository
 import no.nav.helse.fritakagp.domain.GravidSoeknad
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows


### PR DESCRIPTION
Legger til `sendtAvNavn` i domain/{GravidKrav,GravidSoeknad,KroniskKrav,KroniskSoeknad}

Endrer slik at `sendtAvNavn` blir benyttet i stedet for `sendtAv` (som inneholder fnr) i GravidKravKvittering, GravidSoeknadKvittering, KroniskKravKvittering, og KroniskSoeknadKvittering.

I frontend må vi [endre](https://github.com/navikt/fritak-agp-frontend/search?p=2&q=sendtAv) fra å bruke `sendtAv` til `sendtAvNavn`

Endrer dette feltet i kvitteringen
![fritak_kvittering](https://user-images.githubusercontent.com/701351/133253567-3b8d55ec-aae6-43fe-8a4f-851a9908e9ae.png)
