### PR TITLE
Sladder fnr til bruk som tittel i altinnkvittering

### DIFF
--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/utils.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/utils.kt
@@ -15,6 +15,10 @@ enum class GodkjenteFiletyper(val beskrivelse : String) {
 }
 val SOEKAND_BESKRIVELSE_DATE_FORMAT = DateTimeFormatter.ofPattern("dd.MM.yyyy")
 
+fun sladdFnr (fnr: String): String {
+    return fnr.take(6) + "*****"
+}
+
 fun generereGravidSoeknadBeskrivelse(soeknad : GravidSoeknad, desc : String) : String {
     val terminaDatoIkkeOppgitt = "Ikke oppgitt"
     return buildString {

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/GravidKravKvittering.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/GravidKravKvittering.kt
@@ -6,6 +6,7 @@ import no.altinn.schemas.services.serviceengine.correspondence._2010._10.InsertC
 import no.altinn.services.serviceengine.correspondence._2009._10.ICorrespondenceAgencyExternalBasic
 import no.altinn.services.serviceengine.correspondence._2009._10.ICorrespondenceAgencyExternalBasicInsertCorrespondenceBasicV2AltinnFaultFaultFaultMessage
 import no.nav.helse.fritakagp.domain.GravidKrav
+import no.nav.helse.fritakagp.domain.sladdFnr
 import no.nav.helse.fritakagp.processing.kronisk.krav.lagrePerioder
 import java.time.format.DateTimeFormatter
 
@@ -46,7 +47,8 @@ class GravidKravAltinnKvitteringSender(
 
     fun mapKvitteringTilInsertCorrespondence(kvittering: GravidKrav): InsertCorrespondenceV2 {
         val dateTimeFormatterMedKl = DateTimeFormatter.ofPattern("dd.MM.yyyy 'kl.' HH:mm")
-        val tittel = "Kvittering for mottatt refusjonskrav fra arbeidsgiverperioden grunnet graviditet"
+        val sladdetFnr = sladdFnr(kvittering.identitetsnummer)
+        val tittel = "$sladdetFnr - Kvittering for mottatt refusjonskrav fra arbeidsgiverperioden grunnet graviditet"
 
         val innhold = """
         <html>

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/soeknad/GravidSoeknadKvittering.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/soeknad/GravidSoeknadKvittering.kt
@@ -8,6 +8,7 @@ import no.altinn.services.serviceengine.correspondence._2009._10.ICorrespondence
 import no.nav.helse.fritakagp.domain.GravidSoeknad
 import no.nav.helse.fritakagp.domain.Omplassering
 import no.nav.helse.fritakagp.domain.Tiltak
+import no.nav.helse.fritakagp.domain.sladdFnr
 import java.time.format.DateTimeFormatter
 
 interface GravidSoeknadKvitteringSender {
@@ -47,7 +48,8 @@ class GravidSoeknadAltinnKvitteringSender(
 
     fun mapKvitteringTilInsertCorrespondence(kvittering: GravidSoeknad): InsertCorrespondenceV2 {
         val dateTimeFormatterMedKl = DateTimeFormatter.ofPattern("dd.MM.yyyy 'kl.' HH:mm")
-        val tittel = "Kvittering for mottatt søknad om fritak fra arbeidsgiverperioden grunnet graviditet"
+        val sladdetFnr = sladdFnr(kvittering.identitetsnummer)
+        val tittel = "$sladdetFnr - Kvittering for mottatt søknad om fritak fra arbeidsgiverperioden grunnet graviditet"
 
         val innhold = """
         <html>

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravKvittering.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravKvittering.kt
@@ -7,6 +7,7 @@ import no.altinn.services.serviceengine.correspondence._2009._10.ICorrespondence
 import no.altinn.services.serviceengine.correspondence._2009._10.ICorrespondenceAgencyExternalBasicInsertCorrespondenceBasicV2AltinnFaultFaultFaultMessage
 import no.nav.helse.fritakagp.domain.Arbeidsgiverperiode
 import no.nav.helse.fritakagp.domain.KroniskKrav
+import no.nav.helse.fritakagp.domain.sladdFnr
 import java.time.format.DateTimeFormatter
 
 interface KroniskKravKvitteringSender {
@@ -46,7 +47,8 @@ class KroniskKravAltinnKvitteringSender(
 
     fun mapKvitteringTilInsertCorrespondence(kvittering: KroniskKrav): InsertCorrespondenceV2 {
         val dateTimeFormatterMedKl = DateTimeFormatter.ofPattern("dd.MM.yyyy 'kl.' HH:mm")
-        val tittel = "Kvittering for mottatt refusjonskrav fra arbeidsgiverperioden grunnet kronisk sykdom"
+        val sladdetFnr = sladdFnr(kvittering.identitetsnummer)
+        val tittel = "$sladdetFnr - Kvittering for mottatt refusjonskrav fra arbeidsgiverperioden grunnet kronisk sykdom"
 
         val innhold = """
         <html>

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/soeknad/KroniskSoeknadKvittering.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/soeknad/KroniskSoeknadKvittering.kt
@@ -6,6 +6,7 @@ import no.altinn.schemas.services.serviceengine.correspondence._2010._10.InsertC
 import no.altinn.services.serviceengine.correspondence._2009._10.ICorrespondenceAgencyExternalBasic
 import no.altinn.services.serviceengine.correspondence._2009._10.ICorrespondenceAgencyExternalBasicInsertCorrespondenceBasicV2AltinnFaultFaultFaultMessage
 import no.nav.helse.fritakagp.domain.KroniskSoeknad
+import no.nav.helse.fritakagp.domain.sladdFnr
 import java.time.format.DateTimeFormatter
 
 interface KroniskSoeknadKvitteringSender {
@@ -45,7 +46,8 @@ class KroniskSoeknadAltinnKvitteringSender(
 
     fun mapKvitteringTilInsertCorrespondence(kvittering: KroniskSoeknad): InsertCorrespondenceV2 {
         val dateTimeFormatterMedKl = DateTimeFormatter.ofPattern("dd.MM.yyyy 'kl.' HH:mm")
-        val tittel = "Kvittering for mottatt søknad om fritak fra arbeidsgiverperioden grunnet kronisk sykdom"
+        val sladdetFnr = sladdFnr(kvittering.identitetsnummer)
+        val tittel = "$sladdetFnr - Kvittering for mottatt søknad om fritak fra arbeidsgiverperioden grunnet kronisk sykdom"
 
         val innhold = """
         <html>


### PR DESCRIPTION
Arbeidsgivere med mange innslag i altinn meldingsboks sliter med sortering.

Ønske om å legge inn prefiks med fødselsdato i headingen på altinnmeldingene (kvitteringene) i fritak. Gjelder både søknader og refusjoner.

Format på fødselsdato:

DDMMYYYY****** (***** representerer de skjulte sifrene i fnr).