### PR TITLE
Filnavn uten æøå

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     implementation("javax.ws.rs:javax.ws.rs-api:2.1.1")
     implementation("no.nav.security:mock-oauth2-server:$mockOAuth2ServerVersion")
     implementation("no.nav.helsearbeidsgiver:helse-arbeidsgiver-felles-backend:2022.01.18-08-47-f6aa0")
+    implementation("no.nav.helsearbeidsgiver:utils:0.2.0")
     implementation("no.nav.common:log:2.2020.10.27_15.17-901cc4cfbbe4")
     implementation(kotlin("stdlib"))
     implementation("org.slf4j:slf4j-api:1.7.30")

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/BeloepBeregning.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/BeloepBeregning.kt
@@ -1,13 +1,13 @@
 package no.nav.helse.fritakagp.domain
 
-import no.nav.helse.fritakagp.integration.GrunnbeløpClient
+import no.nav.helse.fritakagp.integration.GrunnbeloepClient
 import java.math.BigDecimal
 import java.math.RoundingMode
 
-class BeløpBeregning(
-    grunnbeløpClient: GrunnbeløpClient
+class BeloepBeregning(
+    grunnbeloepClient: GrunnbeloepClient
 ) {
-    private val seksG = grunnbeløpClient.hentGrunnbeløp().grunnbeløp * 6.0
+    private val seksG = grunnbeloepClient.hentGrunnbeløp().grunnbeløp * 6.0
 
     fun beregnBeløpKronisk(krav: KroniskKrav) = beregnPeriodeData(krav.perioder, krav.antallDager)
 

--- a/src/main/kotlin/no/nav/helse/fritakagp/integration/GrunnbeloepClient.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/integration/GrunnbeloepClient.kt
@@ -1,26 +1,26 @@
 package no.nav.helse.fritakagp.integration
 
-import io.ktor.client.*
-import io.ktor.client.request.*
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.url
 import kotlinx.coroutines.runBlocking
 import no.nav.helse.arbeidsgiver.utils.SimpleHashMapCache
 import java.time.Duration
 import java.time.LocalDate
 
-class GrunnbeloepClient(val httpClient: HttpClient) {
-    val cache = SimpleHashMapCache<GrunnbeløpInfo>(Duration.ofDays(1), 2)
+class GrunnbeloepClient(
+    private val httpClient: HttpClient,
+) {
+    private val cache = SimpleHashMapCache<GrunnbeløpInfo>(Duration.ofDays(1), 2)
 
-    fun hentGrunnbeløp(): GrunnbeløpInfo {
-        if (cache.hasValidCacheEntry("g")) return cache.get("g")
-
-        val g = runBlocking {
-            httpClient.get<GrunnbeløpInfo> {
-                url("https://g.nav.no/api/v1/grunnbeløp")
+    fun hentGrunnbeløp(): GrunnbeløpInfo =
+        cache.use("g") {
+            runBlocking {
+                httpClient.get {
+                    url("https://g.nav.no/api/v1/grunnbeløp")
+                }
             }
         }
-        cache.put("g", g)
-        return g
-    }
 }
 
 /**

--- a/src/main/kotlin/no/nav/helse/fritakagp/integration/GrunnbeloepClient.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/integration/GrunnbeloepClient.kt
@@ -7,7 +7,7 @@ import no.nav.helse.arbeidsgiver.utils.SimpleHashMapCache
 import java.time.Duration
 import java.time.LocalDate
 
-class GrunnbeløpClient(val httpClient: HttpClient) {
+class GrunnbeloepClient(val httpClient: HttpClient) {
     val cache = SimpleHashMapCache<GrunnbeløpInfo>(Duration.ofDays(1), 2)
 
     fun hentGrunnbeløp(): GrunnbeløpInfo {

--- a/src/main/kotlin/no/nav/helse/fritakagp/integration/GrunnbeloepClient.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/integration/GrunnbeloepClient.kt
@@ -4,19 +4,19 @@ import io.ktor.client.HttpClient
 import io.ktor.client.request.get
 import io.ktor.client.request.url
 import kotlinx.coroutines.runBlocking
-import no.nav.helse.arbeidsgiver.utils.SimpleHashMapCache
-import java.time.Duration
+import no.nav.helsearbeidsgiver.utils.cache.LocalCache
 import java.time.LocalDate
+import kotlin.time.Duration.Companion.days
 
 class GrunnbeloepClient(
     private val httpClient: HttpClient,
 ) {
-    private val cache = SimpleHashMapCache<GrunnbeløpInfo>(Duration.ofDays(1), 5)
+    private val cache = LocalCache<GrunnbeløpInfo>(1.days, 5)
 
     fun hentGrunnbeløp(dato: LocalDate): GrunnbeløpInfo {
         val cacheKey = if (dato.month.value >= 5) "${dato.year}-05" else "${dato.year - 1}-05"
 
-        return cache.use(cacheKey) {
+        return cache.get(cacheKey) {
             runBlocking {
                 httpClient.get {
                     url("https://g.nav.no/api/v1/grunnbeløp?dato=$dato")

--- a/src/main/kotlin/no/nav/helse/fritakagp/integration/Utils.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/integration/Utils.kt
@@ -1,7 +1,0 @@
-package no.nav.helse.fritakagp.integration
-
-import no.nav.helse.arbeidsgiver.utils.SimpleHashMapCache
-
-fun <T : Any> SimpleHashMapCache<T>.use(cacheKey: String, fn: () -> T): T =
-    if (this.hasValidCacheEntry(cacheKey)) this.get(cacheKey)
-    else fn().also { this.put(cacheKey, it) }

--- a/src/main/kotlin/no/nav/helse/fritakagp/integration/Utils.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/integration/Utils.kt
@@ -1,0 +1,7 @@
+package no.nav.helse.fritakagp.integration
+
+import no.nav.helse.arbeidsgiver.utils.SimpleHashMapCache
+
+fun <T : Any> SimpleHashMapCache<T>.use(cacheKey: String, fn: () -> T): T =
+    if (this.hasValidCacheEntry(cacheKey)) this.get(cacheKey)
+    else fn().also { this.put(cacheKey, it) }

--- a/src/main/kotlin/no/nav/helse/fritakagp/integration/altinn/CachedAuthRepo.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/integration/altinn/CachedAuthRepo.kt
@@ -3,22 +3,16 @@ package no.nav.helse.fritakagp.integration.altinn
 import no.nav.helse.arbeidsgiver.integrasjoner.altinn.AltinnOrganisasjon
 import no.nav.helse.arbeidsgiver.utils.SimpleHashMapCache
 import no.nav.helse.arbeidsgiver.web.auth.AltinnOrganisationsRepository
-import org.slf4j.LoggerFactory
+import no.nav.helse.fritakagp.integration.use
 import java.time.Duration
 
-class CachedAuthRepo(private val sourceRepo: AltinnOrganisationsRepository) : AltinnOrganisationsRepository {
-    val cache = SimpleHashMapCache<Set<AltinnOrganisasjon>>(Duration.ofMinutes(60), 100)
-    val logger = LoggerFactory.getLogger(CachedAuthRepo::class.java)
+class CachedAuthRepo(
+    private val sourceRepo: AltinnOrganisationsRepository,
+) : AltinnOrganisationsRepository {
+    private val cache = SimpleHashMapCache<Set<AltinnOrganisasjon>>(Duration.ofMinutes(60), 100)
 
-    override fun hentOrgMedRettigheterForPerson(identitetsnummer: String): Set<AltinnOrganisasjon> {
-        if (cache.hasValidCacheEntry(identitetsnummer)) {
-            logger.debug("Cache hit")
-            return cache.get(identitetsnummer)
+    override fun hentOrgMedRettigheterForPerson(identitetsnummer: String): Set<AltinnOrganisasjon> =
+        cache.use(identitetsnummer) {
+            sourceRepo.hentOrgMedRettigheterForPerson(identitetsnummer)
         }
-        logger.debug("Cache miss")
-
-        val acl = sourceRepo.hentOrgMedRettigheterForPerson(identitetsnummer)
-        cache.put(identitetsnummer, acl)
-        return acl
-    }
 }

--- a/src/main/kotlin/no/nav/helse/fritakagp/integration/altinn/CachedAuthRepo.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/integration/altinn/CachedAuthRepo.kt
@@ -1,18 +1,17 @@
 package no.nav.helse.fritakagp.integration.altinn
 
 import no.nav.helse.arbeidsgiver.integrasjoner.altinn.AltinnOrganisasjon
-import no.nav.helse.arbeidsgiver.utils.SimpleHashMapCache
 import no.nav.helse.arbeidsgiver.web.auth.AltinnOrganisationsRepository
-import no.nav.helse.fritakagp.integration.use
-import java.time.Duration
+import no.nav.helsearbeidsgiver.utils.cache.LocalCache
+import kotlin.time.Duration.Companion.minutes
 
 class CachedAuthRepo(
     private val sourceRepo: AltinnOrganisationsRepository,
 ) : AltinnOrganisationsRepository {
-    private val cache = SimpleHashMapCache<Set<AltinnOrganisasjon>>(Duration.ofMinutes(60), 100)
+    private val cache = LocalCache<Set<AltinnOrganisasjon>>(60.minutes, 100)
 
     override fun hentOrgMedRettigheterForPerson(identitetsnummer: String): Set<AltinnOrganisasjon> =
-        cache.use(identitetsnummer) {
+        cache.get(identitetsnummer) {
             sourceRepo.hentOrgMedRettigheterForPerson(identitetsnummer)
         }
 }

--- a/src/main/kotlin/no/nav/helse/fritakagp/koin/ExternalSystemsModule.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/koin/ExternalSystemsModule.kt
@@ -15,7 +15,7 @@ import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlClient
 import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlClientImpl
 import no.nav.helse.arbeidsgiver.system.getString
 import no.nav.helse.arbeidsgiver.web.auth.AltinnOrganisationsRepository
-import no.nav.helse.fritakagp.integration.GrunnbeløpClient
+import no.nav.helse.fritakagp.integration.GrunnbeloepClient
 import no.nav.helse.fritakagp.integration.altinn.CachedAuthRepo
 import no.nav.helse.fritakagp.integration.brreg.BrregClient
 import no.nav.helse.fritakagp.integration.brreg.BrregClientImpl
@@ -53,7 +53,7 @@ fun Module.externalSystemClients(config: ApplicationConfig) {
         )
     } bind AltinnOrganisationsRepository::class
 
-    single { GrunnbeløpClient(get()) }
+    single { GrunnbeloepClient(get()) }
 
     single(named("OPPGAVE")) {
         val clientConfig = OAuth2ClientPropertiesConfig(config, "oppgavescope")

--- a/src/main/kotlin/no/nav/helse/fritakagp/koin/LocalKoinProfile.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/koin/LocalKoinProfile.kt
@@ -10,8 +10,8 @@ import no.nav.helse.arbeidsgiver.web.auth.AltinnAuthorizer
 import no.nav.helse.arbeidsgiver.web.auth.DefaultAltinnAuthorizer
 import no.nav.helse.fritakagp.datapakke.DatapakkePublisherJob
 import no.nav.helse.fritakagp.db.*
-import no.nav.helse.fritakagp.domain.BeløpBeregning
-import no.nav.helse.fritakagp.integration.GrunnbeløpClient
+import no.nav.helse.fritakagp.domain.BeloepBeregning
+import no.nav.helse.fritakagp.integration.GrunnbeloepClient
 import no.nav.helse.fritakagp.integration.kafka.*
 import no.nav.helse.fritakagp.processing.brukernotifikasjon.BrukernotifikasjonProcessor
 import no.nav.helse.fritakagp.processing.gravid.krav.*
@@ -26,8 +26,8 @@ import javax.sql.DataSource
 fun localDevConfig(config: ApplicationConfig) = module {
 
     mockExternalDependecies()
-    single { GrunnbeløpClient(get()) }
-    single { BeløpBeregning(get()) }
+    single { GrunnbeloepClient(get()) }
+    single { BeloepBeregning(get()) }
     single { HikariDataSource(createHikariConfig(config.getjdbcUrlFromProperties(), config.getString("database.username"), config.getString("database.password"))) } bind DataSource::class
     single { PostgresGravidSoeknadRepository(get(), get()) } bind GravidSoeknadRepository::class
     single { PostgresGravidKravRepository(get(), get()) } bind GravidKravRepository::class

--- a/src/main/kotlin/no/nav/helse/fritakagp/koin/PreprodKoinProfile.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/koin/PreprodKoinProfile.kt
@@ -2,7 +2,6 @@ package no.nav.helse.fritakagp.koin
 
 import com.zaxxer.hikari.HikariDataSource
 import io.ktor.config.*
-import io.ktor.util.*
 import no.nav.helse.arbeidsgiver.bakgrunnsjobb.BakgrunnsjobbRepository
 import no.nav.helse.arbeidsgiver.bakgrunnsjobb.BakgrunnsjobbService
 import no.nav.helse.arbeidsgiver.bakgrunnsjobb.PostgresBakgrunnsjobbRepository
@@ -12,7 +11,7 @@ import no.nav.helse.arbeidsgiver.web.auth.DefaultAltinnAuthorizer
 import no.nav.helse.fritakagp.MetrikkVarsler
 import no.nav.helse.fritakagp.datapakke.DatapakkePublisherJob
 import no.nav.helse.fritakagp.db.*
-import no.nav.helse.fritakagp.domain.BeløpBeregning
+import no.nav.helse.fritakagp.domain.BeloepBeregning
 import no.nav.helse.fritakagp.integration.altinn.message.Clients
 import no.nav.helse.fritakagp.processing.brukernotifikasjon.BrukernotifikasjonProcessor
 import no.nav.helse.fritakagp.processing.gravid.krav.*
@@ -106,7 +105,7 @@ fun preprodConfig(config: ApplicationConfig) = module {
     single { PdlService(get()) }
 
     single { DefaultAltinnAuthorizer(get()) } bind AltinnAuthorizer::class
-    single { BeløpBeregning(get()) }
+    single { BeloepBeregning(get()) }
 
     single { DatapakkePublisherJob(get(), get(), config.getString("datapakke.api_url"), config.getString("datapakke.id"), get()) }
     single { StatsRepoImpl(get()) } bind IStatsRepo::class

--- a/src/main/kotlin/no/nav/helse/fritakagp/koin/ProdKoinProfile.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/koin/ProdKoinProfile.kt
@@ -2,7 +2,6 @@ package no.nav.helse.fritakagp.koin
 
 import com.zaxxer.hikari.HikariDataSource
 import io.ktor.config.*
-import io.ktor.util.*
 import no.nav.helse.arbeidsgiver.bakgrunnsjobb.BakgrunnsjobbRepository
 import no.nav.helse.arbeidsgiver.bakgrunnsjobb.BakgrunnsjobbService
 import no.nav.helse.arbeidsgiver.bakgrunnsjobb.PostgresBakgrunnsjobbRepository
@@ -12,14 +11,13 @@ import no.nav.helse.arbeidsgiver.web.auth.DefaultAltinnAuthorizer
 import no.nav.helse.fritakagp.MetrikkVarsler
 import no.nav.helse.fritakagp.datapakke.DatapakkePublisherJob
 import no.nav.helse.fritakagp.db.*
-import no.nav.helse.fritakagp.domain.BeløpBeregning
+import no.nav.helse.fritakagp.domain.BeloepBeregning
 import no.nav.helse.fritakagp.integration.altinn.message.Clients
 import no.nav.helse.fritakagp.processing.brukernotifikasjon.BrukernotifikasjonProcessor
 import no.nav.helse.fritakagp.processing.gravid.krav.*
 import no.nav.helse.fritakagp.processing.gravid.soeknad.*
 import no.nav.helse.fritakagp.processing.kronisk.krav.*
 import no.nav.helse.fritakagp.processing.kronisk.soeknad.*
-import no.nav.helse.fritakagp.service.BehandlendeEnhetService
 import no.nav.helse.fritakagp.service.PdlService
 import org.koin.dsl.bind
 import org.koin.dsl.module
@@ -107,7 +105,7 @@ fun prodConfig(config: ApplicationConfig) = module {
     single { PdlService(get()) }
 
     single { DefaultAltinnAuthorizer(get()) } bind AltinnAuthorizer::class
-    single { BeløpBeregning(get()) }
+    single { BeloepBeregning(get()) }
 
     single { DatapakkePublisherJob(get(), get(), config.getString("datapakke.api_url"), config.getString("datapakke.id"), get()) }
     single { StatsRepoImpl(get()) } bind IStatsRepo::class

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/GravidRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/GravidRoutes.kt
@@ -13,7 +13,7 @@ import no.nav.helse.fritakagp.GravidKravMetrics
 import no.nav.helse.fritakagp.GravidSoeknadMetrics
 import no.nav.helse.fritakagp.db.GravidKravRepository
 import no.nav.helse.fritakagp.db.GravidSoeknadRepository
-import no.nav.helse.fritakagp.domain.BeløpBeregning
+import no.nav.helse.fritakagp.domain.BeloepBeregning
 import no.nav.helse.fritakagp.domain.KravStatus
 import no.nav.helse.fritakagp.domain.decodeBase64File
 import no.nav.helse.fritakagp.integration.brreg.BrregClient
@@ -31,7 +31,6 @@ import no.nav.helse.fritakagp.web.auth.hentIdentitetsnummerFraLoginToken
 import no.nav.helse.fritakagp.web.api.resreq.validation.VirusCheckConstraint
 import no.nav.helse.fritakagp.web.api.resreq.validation.extractBase64Del
 import no.nav.helse.fritakagp.web.api.resreq.validation.extractFilExtDel
-import org.valiktor.ConstraintViolation
 import org.valiktor.ConstraintViolationException
 import org.valiktor.DefaultConstraintViolation
 import java.time.LocalDateTime
@@ -48,7 +47,7 @@ fun Route.gravidRoutes(
     virusScanner: VirusScanner,
     bucket: BucketStorage,
     authorizer: AltinnAuthorizer,
-    belopBeregning: BeløpBeregning,
+    belopBeregning: BeloepBeregning,
     aaregClient: AaregArbeidsforholdClient,
     pdlService: PdlService
 ) {

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/KroniskRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/KroniskRoutes.kt
@@ -9,12 +9,11 @@ import io.ktor.routing.*
 import no.nav.helse.arbeidsgiver.bakgrunnsjobb.BakgrunnsjobbService
 import no.nav.helse.arbeidsgiver.integrasjoner.aareg.AaregArbeidsforholdClient
 import no.nav.helse.arbeidsgiver.web.auth.AltinnAuthorizer
-import no.nav.helse.arbeidsgiver.web.validation.OrganisasjonsnummerValidator
 import no.nav.helse.fritakagp.KroniskKravMetrics
 import no.nav.helse.fritakagp.KroniskSoeknadMetrics
 import no.nav.helse.fritakagp.db.KroniskKravRepository
 import no.nav.helse.fritakagp.db.KroniskSoeknadRepository
-import no.nav.helse.fritakagp.domain.BeløpBeregning
+import no.nav.helse.fritakagp.domain.BeloepBeregning
 import no.nav.helse.fritakagp.domain.KravStatus
 import no.nav.helse.fritakagp.integration.brreg.BrregClient
 import no.nav.helse.fritakagp.integration.gcp.BucketStorage
@@ -43,7 +42,7 @@ fun Route.kroniskRoutes(
     virusScanner: VirusScanner,
     bucket: BucketStorage,
     authorizer: AltinnAuthorizer,
-    belopBeregning: BeløpBeregning,
+    belopBeregning: BeloepBeregning,
     aaregClient: AaregArbeidsforholdClient,
     pdlService: PdlService
 ) {

--- a/src/test/kotlin/no/nav/helse/fritakagp/web/api/resreq/GravidKravRequestTest.kt
+++ b/src/test/kotlin/no/nav/helse/fritakagp/web/api/resreq/GravidKravRequestTest.kt
@@ -4,10 +4,8 @@ import io.mockk.every
 import io.mockk.mockk
 import no.nav.helse.AaregTestData
 import no.nav.helse.GravidTestData
-import no.nav.helse.KroniskTestData
-import no.nav.helse.fritakagp.domain.Arbeidsgiverperiode
-import no.nav.helse.fritakagp.domain.BeløpBeregning
-import no.nav.helse.fritakagp.integration.GrunnbeløpClient
+import no.nav.helse.fritakagp.domain.BeloepBeregning
+import no.nav.helse.fritakagp.integration.GrunnbeloepClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import java.time.LocalDate
@@ -109,10 +107,10 @@ class GravidKravRequestTest {
 
     @Test
     fun `Beløp og dagsats er beregnet`() {
-        val grunnbeløpClient = mockk<GrunnbeløpClient>(relaxed = true)
-        every { grunnbeløpClient.hentGrunnbeløp().grunnbeløp } returns 106399
+        val grunnbeloepClient = mockk<GrunnbeloepClient>(relaxed = true)
+        every { grunnbeloepClient.hentGrunnbeløp().grunnbeløp } returns 106399
 
-        val belopBeregning = BeløpBeregning(grunnbeløpClient)
+        val belopBeregning = BeloepBeregning(grunnbeloepClient)
         val krav = GravidTestData.gravidKravRequestValid.toDomain(sendtAv, sendtAvNavn, navn)
         belopBeregning.beregnBeløpGravid(krav)
 
@@ -122,10 +120,10 @@ class GravidKravRequestTest {
 
     @Test
     fun `Beløp har riktig desimaltall`() {
-        val grunnbeløpClient = mockk<GrunnbeløpClient>(relaxed = true)
-        every { grunnbeløpClient.hentGrunnbeløp().grunnbeløp } returns 106399
+        val grunnbeloepClient = mockk<GrunnbeloepClient>(relaxed = true)
+        every { grunnbeloepClient.hentGrunnbeløp().grunnbeløp } returns 106399
 
-        val belopBeregning = BeløpBeregning(grunnbeløpClient)
+        val belopBeregning = BeloepBeregning(grunnbeloepClient)
         val krav = GravidTestData.gravidKravRequestWithWrongDecimal.toDomain(sendtAv, sendtAvNavn, navn)
         belopBeregning.beregnBeløpGravid(krav)
 


### PR DESCRIPTION
Opplevde noen uheldige konsekvenser av ikke-ASCII symboler i filnavnene.

Denne PR-en er en kopi av https://github.com/navikt/fritakagp/pull/197, bare med `preprod/`-prefikset branchnavn. Utenom siste commit er innholdet identisk med https://github.com/navikt/fritakagp/pull/197.