### PR TITLE
Notifikasjonstilgang til krav for brukere

### DIFF
--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/GravidRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/GravidRoutes.kt
@@ -118,7 +118,9 @@ fun Route.gravidRoutes(
                 if (form == null) {
                     call.respond(HttpStatusCode.NotFound)
                 } else {
-                    authorize(authorizer, form.virksomhetsnummer)
+                    if (form.identitetsnummer != innloggetFnr) {
+                        authorize(authorizer, form.virksomhetsnummer)
+                    }
                     form.sendtAvNavn = form.sendtAvNavn ?: pdlService.finnNavn(innloggetFnr)
                     form.navn = form.navn ?: pdlService.finnNavn(form.identitetsnummer)
 

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/GravidRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/GravidRoutes.kt
@@ -118,9 +118,7 @@ fun Route.gravidRoutes(
                 if (form == null) {
                     call.respond(HttpStatusCode.NotFound)
                 } else {
-                    if (form.identitetsnummer != innloggetFnr) {
-                        authorize(authorizer, form.virksomhetsnummer)
-                    }
+                    authorize(authorizer, form.virksomhetsnummer)
                     form.sendtAvNavn = form.sendtAvNavn ?: pdlService.finnNavn(innloggetFnr)
                     form.navn = form.navn ?: pdlService.finnNavn(form.identitetsnummer)
 

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/KroniskRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/KroniskRoutes.kt
@@ -112,9 +112,7 @@ fun Route.kroniskRoutes(
                 if (form == null) {
                     call.respond(HttpStatusCode.NotFound)
                 } else {
-                    if (form.identitetsnummer != innloggetFnr) {
-                        authorize(authorizer, form.virksomhetsnummer)
-                    }
+                    authorize(authorizer, form.virksomhetsnummer)
                     form.sendtAvNavn = form.sendtAvNavn ?: pdlService.finnNavn(innloggetFnr)
                     form.navn = form.navn ?: pdlService.finnNavn(form.identitetsnummer)
 

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/KroniskRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/KroniskRoutes.kt
@@ -112,7 +112,9 @@ fun Route.kroniskRoutes(
                 if (form == null) {
                     call.respond(HttpStatusCode.NotFound)
                 } else {
-                    authorize(authorizer, form.virksomhetsnummer)
+                    if (form.identitetsnummer != innloggetFnr) {
+                        authorize(authorizer, form.virksomhetsnummer)
+                    }
                     form.sendtAvNavn = form.sendtAvNavn ?: pdlService.finnNavn(innloggetFnr)
                     form.navn = form.navn ?: pdlService.finnNavn(form.identitetsnummer)
 


### PR DESCRIPTION
Fikk melding om:

> Varslet sender bruker til arbeidsgiver side på nav.no Bruker varsles om at arbeidsgiver har sendt inn søknad om fritak for ag-periode, når bruker trykker på lenken kommer hun til arbeidsgiver side på nav.no. https://arbeidsgiver.nav.no/fritak-agp/nb/notifikasjon/kronisk/krav/<id>

Ser at vi har fjernet tilgang for at innlogget bruker som kravet gjelder skal kunne hente krav via GET.
