### PR TITLE
Legger til referansenummer for søknader og krav

### DIFF
--- a/src/main/kotlin/no/nav/helse/fritakagp/db/ReferanseRepository.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/db/ReferanseRepository.kt
@@ -1,0 +1,51 @@
+package no.nav.helse.fritakagp.db
+
+import java.sql.SQLException
+import java.util.UUID
+import javax.sql.DataSource
+
+interface ReferanseRepository {
+    fun getOrInsertReferanse(id: UUID): Int
+    fun delete(id: UUID): Int
+}
+
+class ReferanseRepositoryImpl(val ds: DataSource) : ReferanseRepository {
+    private val tableName = "referanse"
+
+    private val getReferanseByUUIDStatement = """SELECT referansenummer FROM $tableName WHERE uuid = (?::uuid) LIMIT 1;"""
+    private val insertUUIDStatement = """INSERT INTO $tableName (uuid) VALUES (?::uuid) returning referansenummer;"""
+    private val deleteStatement = """DELETE FROM $tableName WHERE uuid = (?::uuid)"""
+
+    override fun getOrInsertReferanse(id: UUID): Int {
+        ds.connection.use { con ->
+            val res = con.prepareStatement(getReferanseByUUIDStatement).apply {
+                setString(1, id.toString())
+            }.executeQuery()
+            if (res.next()) {
+                return res.getInt("referansenummer")
+            }
+            return insertUUID(id)
+        }
+    }
+
+    private fun insertUUID(id: UUID): Int {
+        ds.connection.use { con ->
+            val res = con.prepareStatement(insertUUIDStatement).apply {
+                setString(1, id.toString())
+            }.executeQuery()
+            if (res.next()) {
+                return res.getInt("referansenummer")
+            } else {
+                throw SQLException("Insert referansenummer failed. This should not have happened")
+            }
+        }
+    }
+
+    override fun delete(id: UUID): Int {
+        ds.connection.use { con ->
+            return con.prepareStatement(deleteStatement).apply {
+                setString(1, id.toString())
+            }.executeUpdate()
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/GravidKrav.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/GravidKrav.kt
@@ -34,7 +34,8 @@ data class GravidKrav(
     var aarsakEndring: String? = null,
     var endretDato: LocalDateTime? = null,
 
-    var arbeidsgiverSakId: String? = null
+    var arbeidsgiverSakId: String? = null,
+    var referansenummer: Int? = null
 ) : SimpleJsonbEntity {
     companion object {
         const val tittel = "Krav om refusjon av arbeidsgiverperioden - graviditet"

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/GravidSoeknad.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/GravidSoeknad.kt
@@ -33,7 +33,8 @@ data class GravidSoeknad(
      */
     var oppgaveId: String? = null,
     // Må være null for tidligere verdier er lagret med null
-    var sendtAvNavn: String? = null
+    var sendtAvNavn: String? = null,
+    var referansenummer: Int? = null
 ) : SimpleJsonbEntity {
     companion object {
         const val tittel = "Søknad om fritak fra arbeidsgiverperioden - graviditet"

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskKrav.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskKrav.kt
@@ -34,7 +34,8 @@ data class KroniskKrav(
     var aarsakEndring: String? = null,
     var endretDato: LocalDateTime? = null,
 
-    var arbeidsgiverSakId: String? = null
+    var arbeidsgiverSakId: String? = null,
+    var referansenummer: Int? = null
 ) : SimpleJsonbEntity {
     companion object {
         const val tittel = "Krav om refusjon av arbeidsgiverperioden - kronisk eller langvarig sykdom"

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskSoeknad.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskSoeknad.kt
@@ -32,7 +32,8 @@ data class KroniskSoeknad(
      */
     var oppgaveId: String? = null,
     // Må være null for tidligere verdier er lagret med null
-    var sendtAvNavn: String? = null
+    var sendtAvNavn: String? = null,
+    var referansenummer: Int? = null
 ) : SimpleJsonbEntity {
     companion object {
         const val tittel = "Søknad om refusjon av arbeidsgiverperioden - kronisk eller langvarig sykdom"

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/utils.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/utils.kt
@@ -28,6 +28,7 @@ fun generereGravidSoeknadBeskrivelse(soeknad: GravidSoeknad, desc: String): Stri
     return buildString {
         appendLine(desc)
         appendLine("Mottatt: ${soeknad.opprettet.format(TIMESTAMP_FORMAT)}")
+        appendLine("Referansenummer: ${soeknad.referansenummer}")
         appendLine("Person (FNR): ${soeknad.identitetsnummer}")
         appendLine("Termindato: ${soeknad.termindato?.format(DATE_FORMAT) ?: terminaDatoIkkeOppgitt}")
         appendLine("Arbeidsgiver oppgitt i søknad: ${soeknad.virksomhetsnavn} (${soeknad.virksomhetsnummer})")
@@ -52,6 +53,7 @@ fun generereKroniskSoeknadBeskrivelse(soeknad: KroniskSoeknad, desc: String): St
     return buildString {
         appendLine(desc)
         appendLine("Mottatt: ${soeknad.opprettet.format(TIMESTAMP_FORMAT)}")
+        appendLine("Referansenummer: ${soeknad.referansenummer}")
         appendLine("Person (FNR): ${soeknad.identitetsnummer}")
         appendLine("Arbeidsgiver oppgitt i søknad: ${soeknad.virksomhetsnavn} (${soeknad.virksomhetsnummer})")
         if (soeknad.ikkeHistoriskFravaer) {
@@ -77,6 +79,7 @@ fun generereKroniskKravBeskrivelse(krav: KroniskKrav, desc: String): String {
     return buildString {
         appendLine(desc)
         appendLine("Mottatt: ${krav.opprettet.format(TIMESTAMP_FORMAT)}")
+        appendLine("Referansenummer: ${krav.referansenummer}")
         appendLine("Person (FNR): ${krav.identitetsnummer}")
         appendLine("Arbeidsgiver oppgitt i krav: ${krav.virksomhetsnavn} (${krav.virksomhetsnummer})")
         appendLine("Antall lønnsdager: ${krav.antallDager}")
@@ -101,6 +104,7 @@ fun generereGravidkKravBeskrivelse(krav: GravidKrav, desc: String): String {
     return buildString {
         appendLine(desc)
         appendLine("Mottatt: ${krav.opprettet.format(TIMESTAMP_FORMAT)}")
+        appendLine("Referansenummer: ${krav.referansenummer}")
         appendLine("Person (FNR): ${krav.identitetsnummer}")
         appendLine("Arbeidsgiver oppgitt i krav: ${krav.virksomhetsnavn} (${krav.virksomhetsnummer})")
         appendLine("Antall lønnsdager: ${krav.antallDager}")

--- a/src/main/kotlin/no/nav/helse/fritakagp/koin/LocalKoinProfile.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/koin/LocalKoinProfile.kt
@@ -18,6 +18,8 @@ import no.nav.helse.fritakagp.db.PostgresGravidKravRepository
 import no.nav.helse.fritakagp.db.PostgresGravidSoeknadRepository
 import no.nav.helse.fritakagp.db.PostgresKroniskKravRepository
 import no.nav.helse.fritakagp.db.PostgresKroniskSoeknadRepository
+import no.nav.helse.fritakagp.db.ReferanseRepository
+import no.nav.helse.fritakagp.db.ReferanseRepositoryImpl
 import no.nav.helse.fritakagp.db.StatsRepoImpl
 import no.nav.helse.fritakagp.db.createHikariConfig
 import no.nav.helse.fritakagp.domain.BeloepBeregning
@@ -72,6 +74,7 @@ fun localDevConfig(config: ApplicationConfig) = module {
     single { PostgresGravidKravRepository(get(), get()) } bind GravidKravRepository::class
     single { PostgresKroniskSoeknadRepository(get(), get()) } bind KroniskSoeknadRepository::class
     single { PostgresKroniskKravRepository(get(), get()) } bind KroniskKravRepository::class
+    single { ReferanseRepositoryImpl(get()) } bind ReferanseRepository::class
 
     single { SoeknadmeldingKafkaProducer(localCommonKafkaProps(), config.getString("kafka_soeknad_topic_name"), get(), StringKafkaProducerFactory()) } bind SoeknadmeldingSender::class
     single { KravmeldingKafkaProducer(localCommonKafkaProps(), config.getString("kafka_krav_topic_name"), get(), StringKafkaProducerFactory()) } bind KravmeldingSender::class
@@ -83,7 +86,7 @@ fun localDevConfig(config: ApplicationConfig) = module {
     single { GravidKravProcessor(get(), get(), get(), get(), get(), GravidKravPDFGenerator(), get(), get(), get(), get()) }
     single { GravidKravSlettProcessor(get(), get(), get(), get(), get(), GravidKravPDFGenerator(), get(), get(), get(), get(), get()) }
     single { KroniskSoeknadProcessor(get(), get(), get(), get(), get(), KroniskSoeknadPDFGenerator(), get(), get(), get(), get()) }
-    single { KroniskKravProcessor(get(), get(), get(), get(), get(), KroniskKravPDFGenerator(), get(), get(), get(), get()) }
+    single { KroniskKravProcessor(get(), get(), get(), get(), get(), KroniskKravPDFGenerator(), get(), get(), get(), get(), get()) }
     single { KroniskKravSlettProcessor(get(), get(), get(), get(), get(), KroniskKravPDFGenerator(), get(), get(), get(), get()) }
 
     single { GravidSoeknadKvitteringSenderDummy() } bind GravidSoeknadKvitteringSender::class

--- a/src/main/kotlin/no/nav/helse/fritakagp/koin/PreprodKoinProfile.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/koin/PreprodKoinProfile.kt
@@ -19,6 +19,8 @@ import no.nav.helse.fritakagp.db.PostgresGravidKravRepository
 import no.nav.helse.fritakagp.db.PostgresGravidSoeknadRepository
 import no.nav.helse.fritakagp.db.PostgresKroniskKravRepository
 import no.nav.helse.fritakagp.db.PostgresKroniskSoeknadRepository
+import no.nav.helse.fritakagp.db.ReferanseRepository
+import no.nav.helse.fritakagp.db.ReferanseRepositoryImpl
 import no.nav.helse.fritakagp.db.StatsRepoImpl
 import no.nav.helse.fritakagp.db.createHikariConfig
 import no.nav.helse.fritakagp.domain.BeloepBeregning
@@ -73,6 +75,7 @@ fun preprodConfig(config: ApplicationConfig) = module {
     single { PostgresKroniskSoeknadRepository(get(), get()) } bind KroniskSoeknadRepository::class
     single { PostgresGravidKravRepository(get(), get()) } bind GravidKravRepository::class
     single { PostgresKroniskKravRepository(get(), get()) } bind KroniskKravRepository::class
+    single { ReferanseRepositoryImpl(get()) } bind ReferanseRepository::class
 
     single { PostgresBakgrunnsjobbRepository(get()) } bind BakgrunnsjobbRepository::class
     single { BakgrunnsjobbService(get(), bakgrunnsvarsler = MetrikkVarsler()) }
@@ -82,7 +85,7 @@ fun preprodConfig(config: ApplicationConfig) = module {
     single { GravidKravSlettProcessor(get(), get(), get(), get(), get(), GravidKravPDFGenerator(), get(), get(), get(), get(), get()) }
 
     single { KroniskSoeknadProcessor(get(), get(), get(), get(), get(), KroniskSoeknadPDFGenerator(), get(), get(), get(), get()) }
-    single { KroniskKravProcessor(get(), get(), get(), get(), get(), KroniskKravPDFGenerator(), get(), get(), get(), get()) }
+    single { KroniskKravProcessor(get(), get(), get(), get(), get(), KroniskKravPDFGenerator(), get(), get(), get(), get(), get()) }
     single { KroniskKravSlettProcessor(get(), get(), get(), get(), get(), KroniskKravPDFGenerator(), get(), get(), get(), get()) }
 
     single { Clients.iCorrespondenceExternalBasic(config.getString("altinn_melding.altinn_endpoint")) }

--- a/src/main/kotlin/no/nav/helse/fritakagp/koin/ProdKoinProfile.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/koin/ProdKoinProfile.kt
@@ -19,6 +19,8 @@ import no.nav.helse.fritakagp.db.PostgresGravidKravRepository
 import no.nav.helse.fritakagp.db.PostgresGravidSoeknadRepository
 import no.nav.helse.fritakagp.db.PostgresKroniskKravRepository
 import no.nav.helse.fritakagp.db.PostgresKroniskSoeknadRepository
+import no.nav.helse.fritakagp.db.ReferanseRepository
+import no.nav.helse.fritakagp.db.ReferanseRepositoryImpl
 import no.nav.helse.fritakagp.db.StatsRepoImpl
 import no.nav.helse.fritakagp.db.createHikariConfig
 import no.nav.helse.fritakagp.domain.BeloepBeregning
@@ -73,6 +75,7 @@ fun prodConfig(config: ApplicationConfig) = module {
     single { PostgresKroniskSoeknadRepository(get(), get()) } bind KroniskSoeknadRepository::class
     single { PostgresGravidKravRepository(get(), get()) } bind GravidKravRepository::class
     single { PostgresKroniskKravRepository(get(), get()) } bind KroniskKravRepository::class
+    single { ReferanseRepositoryImpl(get()) } bind ReferanseRepository::class
 
     single { PostgresBakgrunnsjobbRepository(get()) } bind BakgrunnsjobbRepository::class
     single { BakgrunnsjobbService(get(), bakgrunnsvarsler = MetrikkVarsler()) }
@@ -82,7 +85,7 @@ fun prodConfig(config: ApplicationConfig) = module {
     single { GravidKravSlettProcessor(get(), get(), get(), get(), get(), GravidKravPDFGenerator(), get(), get(), get(), get(), get()) }
 
     single { KroniskSoeknadProcessor(get(), get(), get(), get(), get(), KroniskSoeknadPDFGenerator(), get(), get(), get(), get()) }
-    single { KroniskKravProcessor(get(), get(), get(), get(), get(), KroniskKravPDFGenerator(), get(), get(), get(), get()) }
+    single { KroniskKravProcessor(get(), get(), get(), get(), get(), KroniskKravPDFGenerator(), get(), get(), get(), get(), get()) }
     single { KroniskKravSlettProcessor(get(), get(), get(), get(), get(), KroniskKravPDFGenerator(), get(), get(), get(), get()) }
 
     single { Clients.iCorrespondenceExternalBasic(config.getString("altinn_melding.altinn_endpoint")) }

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/GravidKravPDFGenerator.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/GravidKravPDFGenerator.kt
@@ -41,6 +41,7 @@ class GravidKravPDFGenerator {
         content.setFont(font, FONT_SIZE)
 
         content.writeTextWrapped("Mottatt: ${krav.opprettet.format(TIMESTAMP_FORMAT)}", 4)
+        content.writeTextWrapped("Referansenummer: ${krav.referansenummer}")
         content.writeTextWrapped("Sendt av: ${krav.sendtAvNavn}")
         content.writeTextWrapped("Person navn: ${krav.navn}")
         content.writeTextWrapped("Arbeidsgiver oppgitt i krav: ${krav.virksomhetsnavn} (${krav.virksomhetsnummer})")

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/GravidKravProcessor.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/GravidKravProcessor.kt
@@ -21,6 +21,7 @@ import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlClient
 import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlIdent
 import no.nav.helse.fritakagp.GravidKravMetrics
 import no.nav.helse.fritakagp.db.GravidKravRepository
+import no.nav.helse.fritakagp.db.ReferanseRepository
 import no.nav.helse.fritakagp.domain.GravidKrav
 import no.nav.helse.fritakagp.domain.generereGravidkKravBeskrivelse
 import no.nav.helse.fritakagp.integration.brreg.BrregClient
@@ -43,8 +44,7 @@ class GravidKravProcessor(
     private val om: ObjectMapper,
     private val bucketStorage: BucketStorage,
     private val brregClient: BrregClient,
-    private val behandlendeEnhetService: BehandlendeEnhetService
-
+    private val referanseRepository: ReferanseRepository
 ) : BakgrunnsjobbProsesserer {
     companion object {
         val JOB_TYPE = "gravid-krav-formidling"
@@ -66,6 +66,9 @@ class GravidKravProcessor(
         val krav = getOrThrow(jobb)
 
         try {
+            if (krav.referansenummer == null) {
+                krav.referansenummer = referanseRepository.getOrInsertReferanse(krav.id)
+            }
             if (krav.virksomhetsnavn == null) {
                 runBlocking {
                     krav.virksomhetsnavn = brregClient.getVirksomhetsNavn(krav.virksomhetsnummer)

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/soeknad/GravidSoeknadPDFGenerator.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/soeknad/GravidSoeknadPDFGenerator.kt
@@ -34,6 +34,7 @@ class GravidSoeknadPDFGenerator {
         content.setFont(font, FONT_SIZE)
 
         content.writeTextWrapped("Mottatt: ${TIMESTAMP_FORMAT.format(soeknad.opprettet)}", 4)
+        content.writeTextWrapped("Referansenummer: ${soeknad.referansenummer}")
         content.writeTextWrapped("Sendt av: ${soeknad.sendtAvNavn}")
         content.writeTextWrapped("Person navn: ${soeknad.navn}")
         content.writeTextWrapped("Termindato: ${soeknad.termindato?.format(DATE_FORMAT) ?: terminaDatoIkkeOppgitt}")

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/soeknad/GravidSoeknadProcessor.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/soeknad/GravidSoeknadProcessor.kt
@@ -21,6 +21,7 @@ import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlClient
 import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlIdent
 import no.nav.helse.fritakagp.GravidSoeknadMetrics
 import no.nav.helse.fritakagp.db.GravidSoeknadRepository
+import no.nav.helse.fritakagp.db.ReferanseRepository
 import no.nav.helse.fritakagp.domain.GravidSoeknad
 import no.nav.helse.fritakagp.domain.generereGravidSoeknadBeskrivelse
 import no.nav.helse.fritakagp.integration.brreg.BrregClient
@@ -43,7 +44,7 @@ class GravidSoeknadProcessor(
     private val om: ObjectMapper,
     private val bucketStorage: BucketStorage,
     private val brregClient: BrregClient,
-    private val behandlendeEnhetService: BehandlendeEnhetService
+    private val referanseRepository: ReferanseRepository
 ) : BakgrunnsjobbProsesserer {
     companion object {
         val JOB_TYPE = "gravid-søknad-formidling"
@@ -67,6 +68,9 @@ class GravidSoeknadProcessor(
         requireNotNull(soeknad, { "Jobben indikerte en søknad med id ${jobb.data} men den kunne ikke finnes" })
 
         try {
+            if (soeknad.referansenummer == null) {
+                soeknad.referansenummer = referanseRepository.getOrInsertReferanse(soeknad.id)
+            }
             if (soeknad.virksomhetsnavn == null) {
                 runBlocking {
                     soeknad.virksomhetsnavn = brregClient.getVirksomhetsNavn(soeknad.virksomhetsnummer)

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravPDFGenerator.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravPDFGenerator.kt
@@ -40,6 +40,7 @@ class KroniskKravPDFGenerator {
         content.setFont(font, FONT_SIZE)
 
         content.writeTextWrapped("Mottatt: ${krav.opprettet.format(TIMESTAMP_FORMAT)}", 4)
+        content.writeTextWrapped("Referansenummer: ${krav.referansenummer}")
         content.writeTextWrapped("Sendt av: ${krav.sendtAvNavn}")
         content.writeTextWrapped("Person navn: ${krav.navn}")
         content.writeTextWrapped("Arbeidsgiver oppgitt i krav: ${krav.virksomhetsnavn} (${krav.virksomhetsnummer})")

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravProcessor.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravProcessor.kt
@@ -21,6 +21,7 @@ import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlClient
 import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlIdent
 import no.nav.helse.fritakagp.KroniskKravMetrics
 import no.nav.helse.fritakagp.db.KroniskKravRepository
+import no.nav.helse.fritakagp.db.ReferanseRepository
 import no.nav.helse.fritakagp.domain.KroniskKrav
 import no.nav.helse.fritakagp.domain.generereKroniskKravBeskrivelse
 import no.nav.helse.fritakagp.integration.brreg.BrregClient
@@ -43,7 +44,8 @@ class KroniskKravProcessor(
     private val om: ObjectMapper,
     private val bucketStorage: BucketStorage,
     private val brregClient: BrregClient,
-    private val behandlendeEnhetService: BehandlendeEnhetService
+    private val behandlendeEnhetService: BehandlendeEnhetService,
+    private val referanseRepository: ReferanseRepository
 ) : BakgrunnsjobbProsesserer {
     companion object {
         val JOB_TYPE = "kronisk-krav-formidling"
@@ -66,6 +68,9 @@ class KroniskKravProcessor(
         logger.info("Prosesserer krav ${krav.id}")
 
         try {
+            if (krav.referansenummer == null) {
+                krav.referansenummer = referanseRepository.getOrInsertReferanse(krav.id)
+            }
             if (krav.virksomhetsnavn == null) {
                 runBlocking {
                     krav.virksomhetsnavn = brregClient.getVirksomhetsNavn(krav.virksomhetsnummer)

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/soeknad/KroniskSoeknadPDFGenerator.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/soeknad/KroniskSoeknadPDFGenerator.kt
@@ -36,6 +36,7 @@ class KroniskSoeknadPDFGenerator {
         content.setFont(font, FONT_SIZE)
 
         content.writeTextWrapped("Mottatt: ${soeknad.opprettet.format(TIMESTAMP_FORMAT)}", 4)
+        content.writeTextWrapped("Referansenummer: ${soeknad.referansenummer}")
         content.writeTextWrapped("Sendt av: ${soeknad.sendtAvNavn}")
         content.writeTextWrapped("Person navn: ${soeknad.navn}")
         content.writeTextWrapped("Arbeidsgiver oppgitt i søknad: ${soeknad.virksomhetsnavn} (${soeknad.virksomhetsnummer})")

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/soeknad/KroniskSoeknadProcessor.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/soeknad/KroniskSoeknadProcessor.kt
@@ -21,6 +21,7 @@ import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlClient
 import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlIdent
 import no.nav.helse.fritakagp.KroniskSoeknadMetrics
 import no.nav.helse.fritakagp.db.KroniskSoeknadRepository
+import no.nav.helse.fritakagp.db.ReferanseRepository
 import no.nav.helse.fritakagp.domain.KroniskSoeknad
 import no.nav.helse.fritakagp.domain.generereKroniskSoeknadBeskrivelse
 import no.nav.helse.fritakagp.integration.brreg.BrregClient
@@ -43,7 +44,7 @@ class KroniskSoeknadProcessor(
     private val om: ObjectMapper,
     private val bucketStorage: BucketStorage,
     private val brregClient: BrregClient,
-    private val behandlendeEnhetService: BehandlendeEnhetService
+    private val referanseRepository: ReferanseRepository
 ) : BakgrunnsjobbProsesserer {
     companion object {
         val dokumentasjonBrevkode = "soeknad_om_fritak_fra_agp_dokumentasjon"
@@ -64,6 +65,9 @@ class KroniskSoeknadProcessor(
         val soeknad = getSoeknadOrThrow(jobb)
 
         try {
+            if (soeknad.referansenummer == null) {
+                soeknad.referansenummer = referanseRepository.getOrInsertReferanse(soeknad.id)
+            }
             if (soeknad.virksomhetsnavn == null) {
                 runBlocking {
                     soeknad.virksomhetsnavn = brregClient.getVirksomhetsNavn(soeknad.virksomhetsnummer)

--- a/src/main/resources/db/migration/V9__referanse.sql
+++ b/src/main/resources/db/migration/V9__referanse.sql
@@ -1,0 +1,4 @@
+CREATE TABLE referanse (
+    referansenummer serial PRIMARY KEY,
+    uuid uuid UNIQUE NOT NULL
+);

--- a/src/test/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/GravidKravProcessorTest.kt
+++ b/src/test/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/GravidKravProcessorTest.kt
@@ -28,6 +28,7 @@ import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlHentPersonNavn
 import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlIdent
 import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlPersonNavnMetadata
 import no.nav.helse.fritakagp.db.GravidKravRepository
+import no.nav.helse.fritakagp.db.ReferanseRepository
 import no.nav.helse.fritakagp.domain.GravidKrav
 import no.nav.helse.fritakagp.integration.brreg.BrregClient
 import no.nav.helse.fritakagp.integration.gcp.BucketDocument
@@ -52,8 +53,8 @@ class GravidKravProcessorTest {
     val bucketStorageMock = mockk<BucketStorage>(relaxed = true)
     val bakgrunnsjobbRepomock = mockk<BakgrunnsjobbRepository>(relaxed = true)
     val berregServiceMock = mockk<BrregClient>(relaxed = true)
-    val behandlendeEnhetService = mockk<BehandlendeEnhetService>(relaxed = true)
-    val prosessor = GravidKravProcessor(repositoryMock, joarkMock, oppgaveMock, pdlClientMock, bakgrunnsjobbRepomock, pdfGeneratorMock, objectMapper, bucketStorageMock, berregServiceMock, behandlendeEnhetService)
+    val referanseRepository = mockk<ReferanseRepository>(relaxed = true)
+    val prosessor = GravidKravProcessor(repositoryMock, joarkMock, oppgaveMock, pdlClientMock, bakgrunnsjobbRepomock, pdfGeneratorMock, objectMapper, bucketStorageMock, berregServiceMock, referanseRepository)
     lateinit var krav: GravidKrav
 
     private val oppgaveId = 9999
@@ -166,7 +167,6 @@ class GravidKravProcessorTest {
 
     @Test
     fun `Ved feil i oppgave skal joarkref lagres, og det skal det kastes exception oppover`() {
-
         coEvery { oppgaveMock.opprettOppgave(any(), any()) } throws IOException()
 
         assertThrows<IOException> { prosessor.prosesser(jobb) }

--- a/src/test/kotlin/no/nav/helse/fritakagp/processing/gravid/soeknad/GravidSoeknadProcessorTest.kt
+++ b/src/test/kotlin/no/nav/helse/fritakagp/processing/gravid/soeknad/GravidSoeknadProcessorTest.kt
@@ -29,6 +29,7 @@ import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlHentPersonNavn
 import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlIdent
 import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlPersonNavnMetadata
 import no.nav.helse.fritakagp.db.GravidSoeknadRepository
+import no.nav.helse.fritakagp.db.ReferanseRepository
 import no.nav.helse.fritakagp.domain.GravidSoeknad
 import no.nav.helse.fritakagp.integration.brreg.BrregClient
 import no.nav.helse.fritakagp.integration.gcp.BucketDocument
@@ -54,7 +55,7 @@ class GravidSoeknadProcessorTest {
     val bucketStorageMock = mockk<BucketStorage>(relaxed = true)
     val bakgrunnsjobbRepomock = mockk<BakgrunnsjobbRepository>(relaxed = true)
     val berregServiceMock = mockk<BrregClient>(relaxed = true)
-    val behandlendeEnhetService = mockk<BehandlendeEnhetService>(relaxed = true)
+    val referanseRepository = mockk<ReferanseRepository>(relaxed = true)
     val prosessor = GravidSoeknadProcessor(
         repositoryMock,
         joarkMock,
@@ -65,7 +66,7 @@ class GravidSoeknadProcessorTest {
         objectMapper,
         bucketStorageMock,
         berregServiceMock,
-        behandlendeEnhetService
+        referanseRepository
     )
 
     lateinit var soeknad: GravidSoeknad
@@ -204,7 +205,6 @@ class GravidSoeknadProcessorTest {
 
     @Test
     fun `Ved feil i oppgave skal joarkref lagres, og det skal det kastes exception oppover`() {
-
         coEvery { oppgaveMock.opprettOppgave(any(), any()) } throws IOException()
 
         assertThrows<IOException> { prosessor.prosesser(jobb) }

--- a/src/test/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravProcessorTest.kt
+++ b/src/test/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravProcessorTest.kt
@@ -28,6 +28,7 @@ import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlHentPersonNavn
 import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlIdent
 import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlPersonNavnMetadata
 import no.nav.helse.fritakagp.db.KroniskKravRepository
+import no.nav.helse.fritakagp.db.ReferanseRepository
 import no.nav.helse.fritakagp.domain.KroniskKrav
 import no.nav.helse.fritakagp.integration.brreg.BrregClient
 import no.nav.helse.fritakagp.integration.gcp.BucketDocument
@@ -55,7 +56,8 @@ class KroniskKravProcessorTest {
     val bakgrunnsjobbRepomock = mockk<BakgrunnsjobbRepository>(relaxed = true)
     val berregServiceMock = mockk<BrregClient>(relaxed = true)
     val behandlendeEnhetService = mockk<BehandlendeEnhetService>(relaxed = true)
-    val prosessor = KroniskKravProcessor(repositoryMock, joarkMock, oppgaveMock, pdlClientMock, bakgrunnsjobbRepomock, pdfGeneratorMock, objectMapper, bucketStorageMock, berregServiceMock, behandlendeEnhetService)
+    val referanseRepository = mockk<ReferanseRepository>(relaxed = true)
+    val prosessor = KroniskKravProcessor(repositoryMock, joarkMock, oppgaveMock, pdlClientMock, bakgrunnsjobbRepomock, pdfGeneratorMock, objectMapper, bucketStorageMock, berregServiceMock, behandlendeEnhetService, referanseRepository)
     lateinit var krav: KroniskKrav
 
     private val oppgaveId = 9999
@@ -169,7 +171,6 @@ class KroniskKravProcessorTest {
 
     @Test
     fun `Ved feil i oppgave skal joarkref lagres, og det skal det kastes exception oppover`() {
-
         coEvery { oppgaveMock.opprettOppgave(any(), any()) } throws IOException()
 
         assertThrows<IOException> { prosessor.prosesser(jobb) }

--- a/src/test/kotlin/no/nav/helse/fritakagp/processing/kronisk/soeknad/KroniskSoeknadProcessorTest.kt
+++ b/src/test/kotlin/no/nav/helse/fritakagp/processing/kronisk/soeknad/KroniskSoeknadProcessorTest.kt
@@ -28,6 +28,7 @@ import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlHentPersonNavn
 import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlIdent
 import no.nav.helse.arbeidsgiver.integrasjoner.pdl.PdlPersonNavnMetadata
 import no.nav.helse.fritakagp.db.KroniskSoeknadRepository
+import no.nav.helse.fritakagp.db.ReferanseRepository
 import no.nav.helse.fritakagp.domain.KroniskSoeknad
 import no.nav.helse.fritakagp.integration.brreg.BrregClient
 import no.nav.helse.fritakagp.integration.gcp.BucketDocument
@@ -54,8 +55,8 @@ class KroniskSoeknadProcessorTest {
     val bucketStorageMock = mockk<BucketStorage>(relaxed = true)
     val bakgrunnsjobbRepomock = mockk<BakgrunnsjobbRepository>(relaxed = true)
     val berregServiceMock = mockk<BrregClient>(relaxed = true)
-    val behandlendeEnhetService = mockk<BehandlendeEnhetService>(relaxed = true)
-    val prosessor = KroniskSoeknadProcessor(repositoryMock, joarkMock, oppgaveMock, bakgrunnsjobbRepomock, pdlClientMock, pdfGeneratorMock, objectMapper, bucketStorageMock, berregServiceMock, behandlendeEnhetService)
+    val referanseRepository = mockk<ReferanseRepository>(relaxed = true)
+    val prosessor = KroniskSoeknadProcessor(repositoryMock, joarkMock, oppgaveMock, bakgrunnsjobbRepomock, pdlClientMock, pdfGeneratorMock, objectMapper, bucketStorageMock, berregServiceMock, referanseRepository)
     lateinit var soeknad: KroniskSoeknad
 
     private val oppgaveId = 9999
@@ -169,7 +170,6 @@ class KroniskSoeknadProcessorTest {
 
     @Test
     fun `Ved feil i oppgave skal joarkref lagres, og det skal det kastes exception oppover`() {
-
         coEvery { oppgaveMock.opprettOppgave(any(), any()) } throws IOException()
 
         assertThrows<IOException> { prosessor.prosesser(jobb) }

--- a/src/test/kotlin/no/nav/helse/slowtests/ReferanseRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/ReferanseRepositoryTest.kt
@@ -1,0 +1,36 @@
+package no.nav.helse.slowtests
+
+import com.zaxxer.hikari.HikariDataSource
+import no.nav.helse.fritakagp.db.ReferanseRepositoryImpl
+import no.nav.helse.fritakagp.db.createTestHikariConfig
+import no.nav.helse.slowtests.systemtests.api.SystemTestBase
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.UUID
+
+class ReferanseRepositoryTest : SystemTestBase() {
+
+    lateinit var repo: ReferanseRepositoryImpl
+    val testId = UUID.randomUUID()
+
+    @BeforeEach
+    internal fun setUp() {
+        val ds = HikariDataSource(createTestHikariConfig())
+        repo = ReferanseRepositoryImpl(ds)
+    }
+
+    @AfterEach
+    internal fun tearDown() {
+        repo.delete(testId)
+    }
+
+    @Test
+    fun `test getOrInsertReferanse`() {
+        val result = repo.getOrInsertReferanse(testId)
+        val result2 = repo.getOrInsertReferanse(testId)
+        assertThat(result).isNotEqualTo(0)
+        assertThat(result2).isEqualTo(result)
+    }
+}


### PR DESCRIPTION
> Refusjonskravene bør ha ett referansenummer fra systemet slik at man lettere kan se at man faktisk har åpnet alle refusjonskravene på en bruker.
> 
> Noen ganger sendes det flere refusjonskrav på samme bruker i løpet av få minutter. Med et referansenummer er det lettere å se at du sitter med korrekt krav, om du har åpnet alle kravene osv.
> 
> Det finnes et referansenummer i de PDF’ene som genereres for refusjonskrav dag 6 – koronarelatert fravær, kunne det vært mulig å få inn noe lignende?

Referansenummeret skal være unikt for gravid/kronisk- søknader og krav.
Denne PR-en lager en tabell:
```sql
CREATE TABLE referanse (
   referansenummer serial PRIMARY KEY,
   uuid uuid UNIQUE NOT NULL
);
```

Henter (oppretter hvis det ikke eksisterer) referansenummer med UUID-en i bakgrunnsjobbene og legger det med i PDF og GoSys oppgavetekst.

For å slippe og lage en egen referansetabell er det mulig det er bedre å gjøre dette i stedet:
KroniskKrav har prefiks `KK`
KroniskSoeknad har prefiks `KS`
GravidKrav har prefiks `GK`
GravidSoeknad har prefiks `GS`

Lagt inn en auto-økende referansenummer kolonne i hver av de 4 forskjellige tabellene, og satt dette som referansenummer i PDF-en: `prefiks+referansenummer`

Eventuelt er vel det enkleste er vel å ha UUID_SHORT som referansenummer, men det er ikke så enkelt å lese/bruke for saksbehandlerene.