### PR TITLE
Legger til referansenummer for søknader og krav

### DIFF
--- a/src/main/kotlin/no/nav/helse/fritakagp/db/SimpleJsonbRepositoryBase.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/db/SimpleJsonbRepositoryBase.kt
@@ -1,6 +1,7 @@
 package no.nav.helse.fritakagp.db
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.node.ObjectNode
 import java.sql.Connection
 import java.util.UUID
 import javax.sql.DataSource
@@ -39,6 +40,7 @@ abstract class SimpleJsonbRepositoryBase<T : SimpleJsonbEntity>(
     private val saveStatement = "INSERT INTO $tableName (data) VALUES (?::json);"
     private val updateStatement = "UPDATE $tableName SET data = ?::json WHERE data ->> 'id' = ?"
     private val deleteStatement = """DELETE FROM $tableName WHERE data ->> 'id' = ?"""
+    private val getNextReferanseStatement = "SELECT nextval('referanse_seq')"
 
     override fun getById(id: UUID): T? {
         ds.connection.use {
@@ -57,11 +59,25 @@ abstract class SimpleJsonbRepositoryBase<T : SimpleJsonbEntity>(
     }
 
     override fun insert(entity: T, connection: Connection): T {
-        val json = mapper.writeValueAsString(entity)
+        val referansenummer = getNextReferanse(connection)
+        val entityMedReferansenummer = mapper
+            .readValue(mapper.writeValueAsString(entity), ObjectNode::class.java).apply {
+                put("referansenummer", referansenummer)
+            }
+        val json = mapper.writeValueAsString(entityMedReferansenummer)
+
         connection.prepareStatement(saveStatement).apply {
             setString(1, json)
         }.executeUpdate()
         return entity
+    }
+
+    private fun getNextReferanse(connection: Connection): Int? {
+        val res = connection.prepareStatement(getNextReferanseStatement).executeQuery()
+        if (res.next()) {
+            return res.getInt(1)
+        }
+        return null
     }
 
     override fun insert(entity: T): T {

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/GravidKrav.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/GravidKrav.kt
@@ -34,7 +34,8 @@ data class GravidKrav(
     var aarsakEndring: String? = null,
     var endretDato: LocalDateTime? = null,
 
-    var arbeidsgiverSakId: String? = null
+    var arbeidsgiverSakId: String? = null,
+    var referansenummer: Int? = null
 ) : SimpleJsonbEntity {
     companion object {
         const val tittel = "Krav om refusjon av arbeidsgiverperioden - graviditet"

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/GravidSoeknad.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/GravidSoeknad.kt
@@ -33,7 +33,8 @@ data class GravidSoeknad(
      */
     var oppgaveId: String? = null,
     // Må være null for tidligere verdier er lagret med null
-    var sendtAvNavn: String? = null
+    var sendtAvNavn: String? = null,
+    var referansenummer: Int? = null
 ) : SimpleJsonbEntity {
     companion object {
         const val tittel = "Søknad om fritak fra arbeidsgiverperioden - graviditet"

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskKrav.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskKrav.kt
@@ -34,7 +34,8 @@ data class KroniskKrav(
     var aarsakEndring: String? = null,
     var endretDato: LocalDateTime? = null,
 
-    var arbeidsgiverSakId: String? = null
+    var arbeidsgiverSakId: String? = null,
+    var referansenummer: Int? = null
 ) : SimpleJsonbEntity {
     companion object {
         const val tittel = "Krav om refusjon av arbeidsgiverperioden - kronisk eller langvarig sykdom"

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskSoeknad.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskSoeknad.kt
@@ -32,7 +32,8 @@ data class KroniskSoeknad(
      */
     var oppgaveId: String? = null,
     // Må være null for tidligere verdier er lagret med null
-    var sendtAvNavn: String? = null
+    var sendtAvNavn: String? = null,
+    var referansenummer: Int? = null
 ) : SimpleJsonbEntity {
     companion object {
         const val tittel = "Søknad om refusjon av arbeidsgiverperioden - kronisk eller langvarig sykdom"

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/utils.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/utils.kt
@@ -28,6 +28,7 @@ fun generereGravidSoeknadBeskrivelse(soeknad: GravidSoeknad, desc: String): Stri
     return buildString {
         appendLine(desc)
         appendLine("Mottatt: ${soeknad.opprettet.format(TIMESTAMP_FORMAT)}")
+        appendLine("Referansenummer: ${soeknad.referansenummer}")
         appendLine("Person (FNR): ${soeknad.identitetsnummer}")
         appendLine("Termindato: ${soeknad.termindato?.format(DATE_FORMAT) ?: terminaDatoIkkeOppgitt}")
         appendLine("Arbeidsgiver oppgitt i søknad: ${soeknad.virksomhetsnavn} (${soeknad.virksomhetsnummer})")
@@ -52,6 +53,7 @@ fun generereKroniskSoeknadBeskrivelse(soeknad: KroniskSoeknad, desc: String): St
     return buildString {
         appendLine(desc)
         appendLine("Mottatt: ${soeknad.opprettet.format(TIMESTAMP_FORMAT)}")
+        appendLine("Referansenummer: ${soeknad.referansenummer}")
         appendLine("Person (FNR): ${soeknad.identitetsnummer}")
         appendLine("Arbeidsgiver oppgitt i søknad: ${soeknad.virksomhetsnavn} (${soeknad.virksomhetsnummer})")
         if (soeknad.ikkeHistoriskFravaer) {
@@ -77,6 +79,7 @@ fun generereKroniskKravBeskrivelse(krav: KroniskKrav, desc: String): String {
     return buildString {
         appendLine(desc)
         appendLine("Mottatt: ${krav.opprettet.format(TIMESTAMP_FORMAT)}")
+        appendLine("Referansenummer: ${krav.referansenummer}")
         appendLine("Person (FNR): ${krav.identitetsnummer}")
         appendLine("Arbeidsgiver oppgitt i krav: ${krav.virksomhetsnavn} (${krav.virksomhetsnummer})")
         appendLine("Antall lønnsdager: ${krav.antallDager}")
@@ -101,6 +104,7 @@ fun generereGravidkKravBeskrivelse(krav: GravidKrav, desc: String): String {
     return buildString {
         appendLine(desc)
         appendLine("Mottatt: ${krav.opprettet.format(TIMESTAMP_FORMAT)}")
+        appendLine("Referansenummer: ${krav.referansenummer}")
         appendLine("Person (FNR): ${krav.identitetsnummer}")
         appendLine("Arbeidsgiver oppgitt i krav: ${krav.virksomhetsnavn} (${krav.virksomhetsnummer})")
         appendLine("Antall lønnsdager: ${krav.antallDager}")

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/GravidKravPDFGenerator.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/GravidKravPDFGenerator.kt
@@ -41,6 +41,7 @@ class GravidKravPDFGenerator {
         content.setFont(font, FONT_SIZE)
 
         content.writeTextWrapped("Mottatt: ${krav.opprettet.format(TIMESTAMP_FORMAT)}", 4)
+        content.writeTextWrapped("Referansenummer: ${krav.referansenummer}")
         content.writeTextWrapped("Sendt av: ${krav.sendtAvNavn}")
         content.writeTextWrapped("Person navn: ${krav.navn}")
         content.writeTextWrapped("Arbeidsgiver oppgitt i krav: ${krav.virksomhetsnavn} (${krav.virksomhetsnummer})")

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/soeknad/GravidSoeknadPDFGenerator.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/soeknad/GravidSoeknadPDFGenerator.kt
@@ -34,6 +34,7 @@ class GravidSoeknadPDFGenerator {
         content.setFont(font, FONT_SIZE)
 
         content.writeTextWrapped("Mottatt: ${TIMESTAMP_FORMAT.format(soeknad.opprettet)}", 4)
+        content.writeTextWrapped("Referansenummer: ${soeknad.referansenummer}")
         content.writeTextWrapped("Sendt av: ${soeknad.sendtAvNavn}")
         content.writeTextWrapped("Person navn: ${soeknad.navn}")
         content.writeTextWrapped("Termindato: ${soeknad.termindato?.format(DATE_FORMAT) ?: terminaDatoIkkeOppgitt}")

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravPDFGenerator.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravPDFGenerator.kt
@@ -40,6 +40,7 @@ class KroniskKravPDFGenerator {
         content.setFont(font, FONT_SIZE)
 
         content.writeTextWrapped("Mottatt: ${krav.opprettet.format(TIMESTAMP_FORMAT)}", 4)
+        content.writeTextWrapped("Referansenummer: ${krav.referansenummer}")
         content.writeTextWrapped("Sendt av: ${krav.sendtAvNavn}")
         content.writeTextWrapped("Person navn: ${krav.navn}")
         content.writeTextWrapped("Arbeidsgiver oppgitt i krav: ${krav.virksomhetsnavn} (${krav.virksomhetsnummer})")

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/soeknad/KroniskSoeknadPDFGenerator.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/soeknad/KroniskSoeknadPDFGenerator.kt
@@ -36,6 +36,7 @@ class KroniskSoeknadPDFGenerator {
         content.setFont(font, FONT_SIZE)
 
         content.writeTextWrapped("Mottatt: ${soeknad.opprettet.format(TIMESTAMP_FORMAT)}", 4)
+        content.writeTextWrapped("Referansenummer: ${soeknad.referansenummer}")
         content.writeTextWrapped("Sendt av: ${soeknad.sendtAvNavn}")
         content.writeTextWrapped("Person navn: ${soeknad.navn}")
         content.writeTextWrapped("Arbeidsgiver oppgitt i søknad: ${soeknad.virksomhetsnavn} (${soeknad.virksomhetsnummer})")

--- a/src/main/resources/db/migration/V9__referansenummer.sql
+++ b/src/main/resources/db/migration/V9__referansenummer.sql
@@ -1,0 +1,1 @@
+CREATE SEQUENCE referanse_seq;

--- a/src/test/kotlin/no/nav/helse/slowtests/PostgresGravidKravRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/PostgresGravidKravRepositoryTest.kt
@@ -34,6 +34,7 @@ class PostgresGravidKravRepositoryTest : SystemTestBase() {
     fun `test getById`() {
         val soeknadKroniskResult = repo.getById(testKrav.id)
         assertThat(soeknadKroniskResult).isEqualToIgnoringGivenFields(testKrav, "referansenummer")
+        assertThat(soeknadKroniskResult!!.referansenummer).isNotNull
     }
 
     @Test

--- a/src/test/kotlin/no/nav/helse/slowtests/PostgresGravidKravRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/PostgresGravidKravRepositoryTest.kt
@@ -33,7 +33,7 @@ class PostgresGravidKravRepositoryTest : SystemTestBase() {
     @Test
     fun `test getById`() {
         val soeknadKroniskResult = repo.getById(testKrav.id)
-        assertThat(soeknadKroniskResult).isEqualTo(testKrav)
+        assertThat(soeknadKroniskResult).isEqualToIgnoringGivenFields(testKrav, "referansenummer")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/helse/slowtests/PostgresGravidSoeknadRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/PostgresGravidSoeknadRepositoryTest.kt
@@ -34,6 +34,7 @@ class PostgresGravidSoeknadRepositoryTest : SystemTestBase() {
     fun `finnerDataIDb`() {
         val soeknadGravidResult = repo.getById(testSoeknad.id)
         assertThat(soeknadGravidResult).isEqualToIgnoringGivenFields(testSoeknad, "referansenummer")
+        assertThat(soeknadGravidResult!!.referansenummer).isNotNull
     }
 
     @Test

--- a/src/test/kotlin/no/nav/helse/slowtests/PostgresGravidSoeknadRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/PostgresGravidSoeknadRepositoryTest.kt
@@ -33,7 +33,7 @@ class PostgresGravidSoeknadRepositoryTest : SystemTestBase() {
     @Test
     fun `finnerDataIDb`() {
         val soeknadGravidResult = repo.getById(testSoeknad.id)
-        assertThat(soeknadGravidResult).isEqualTo(testSoeknad)
+        assertThat(soeknadGravidResult).isEqualToIgnoringGivenFields(testSoeknad, "referansenummer")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/helse/slowtests/PostgresKroniskKravRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/PostgresKroniskKravRepositoryTest.kt
@@ -33,7 +33,7 @@ class PostgresKroniskKravRepositoryTest : SystemTestBase() {
     @Test
     fun `test getById`() {
         val soeknadKroniskResult = repo.getById(testKrav.id)
-        assertThat(soeknadKroniskResult).isEqualTo(testKrav)
+        assertThat(soeknadKroniskResult).isEqualToIgnoringGivenFields(testKrav, "referansenummer")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/helse/slowtests/PostgresKroniskKravRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/PostgresKroniskKravRepositoryTest.kt
@@ -34,6 +34,7 @@ class PostgresKroniskKravRepositoryTest : SystemTestBase() {
     fun `test getById`() {
         val soeknadKroniskResult = repo.getById(testKrav.id)
         assertThat(soeknadKroniskResult).isEqualToIgnoringGivenFields(testKrav, "referansenummer")
+        assertThat(soeknadKroniskResult!!.referansenummer).isNotNull
     }
 
     @Test

--- a/src/test/kotlin/no/nav/helse/slowtests/PostgresKroniskSoeknadRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/PostgresKroniskSoeknadRepositoryTest.kt
@@ -34,6 +34,7 @@ class PostgresKroniskSoeknadRepositoryTest : SystemTestBase() {
     fun `finnerDataIDb`() {
         val soeknadKroniskResult = repo.getById(testSoeknad.id)
         assertThat(soeknadKroniskResult).isEqualToIgnoringGivenFields(testSoeknad, "referansenummer")
+        assertThat(soeknadKroniskResult!!.referansenummer).isNotNull
     }
 
     @Test

--- a/src/test/kotlin/no/nav/helse/slowtests/PostgresKroniskSoeknadRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/PostgresKroniskSoeknadRepositoryTest.kt
@@ -33,7 +33,7 @@ class PostgresKroniskSoeknadRepositoryTest : SystemTestBase() {
     @Test
     fun `finnerDataIDb`() {
         val soeknadKroniskResult = repo.getById(testSoeknad.id)
-        assertThat(soeknadKroniskResult).isEqualTo(testSoeknad)
+        assertThat(soeknadKroniskResult).isEqualToIgnoringGivenFields(testSoeknad, "referansenummer")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/GravidSoeknadHTTPTests.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/GravidSoeknadHTTPTests.kt
@@ -42,7 +42,7 @@ class GravidSoeknadHTTPTests : SystemTestBase() {
             loggedInAs(GravidTestData.soeknadGravid.identitetsnummer)
         }
 
-        assertThat(accessGrantedForm).isEqualTo(GravidTestData.soeknadGravid)
+        assertThat(accessGrantedForm).isEqualToIgnoringGivenFields(GravidTestData.soeknadGravid, "referansenummer")
     }
 
     @Test

--- a/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/KroniskSoeknadHTTPTests.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/KroniskSoeknadHTTPTests.kt
@@ -44,7 +44,7 @@ class KroniskSoeknadHTTPTests : SystemTestBase() {
             loggedInAs(KroniskTestData.soeknadKronisk.identitetsnummer)
         }
 
-        Assertions.assertThat(accessGrantedForm).isEqualTo(KroniskTestData.soeknadKronisk)
+        Assertions.assertThat(accessGrantedForm).isEqualToIgnoringGivenFields(KroniskTestData.soeknadKronisk, "referansenummer")
     }
 
     @Test


### PR DESCRIPTION
Obs! Fortsatt litt hackish, rakk ikke å teste på fredag.

> Refusjonskravene bør ha ett referansenummer fra systemet slik at man lettere kan se at man faktisk har åpnet alle refusjonskravene på en bruker.
> 
> Noen ganger sendes det flere refusjonskrav på samme bruker i løpet av få minutter. Med et referansenummer er det lettere å se at du sitter med korrekt krav, om du har åpnet alle kravene osv.
> 
> Det finnes et referansenummer i de PDF’ene som genereres for refusjonskrav dag 6 – koronarelatert fravær, kunne det vært mulig å få inn noe lignende?

Referansenummeret skal være unikt for gravid og kronisk- søknader og krav.
Denne PR-en lager en sekvens:
```sql
CREATE SEQUENCE referanse_seq;
```

...henter neste sekvensnummer, og dytter referansenummeret til data-jsonb feltet ved insert.
```sql
SELECT nextval('referanse_seq')
```

Eventuelt er vel det enkleste er vel å ha UUID_SHORT som referansenummer, men det er kanskje ikke så enkelt å lese/bruke for saksbehandlerene ¯\_(ツ)_/¯