### PR TITLE
Oppdater sakstatus - benytt opprettetDato fra kravet som tidsstempel for status-oppdatering

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ sonarqubeVersion=4.2.1.3168
 # Dependency versions
 altinnClientVersion=0.2.1
 altinnCorrespondenceAgencyVersion=1.2019.09.25-00.21-49b69f0625e0
-arbeidsgiverNotifikasjonKlientVersion=2.2.0
+arbeidsgiverNotifikasjonKlientVersion=2.3.1
 assertJVersion=3.12.2
 brukernotifikasjonSchemasVersion=v2.5.1
 confluentVersion=7.0.1

--- a/src/main/kotlin/no/nav/helse/fritakagp/koin/PreprodKoinProfile.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/koin/PreprodKoinProfile.kt
@@ -144,7 +144,7 @@ fun preprodConfig(env: Env.Preprod): Module = module {
 
     single { BrukernotifikasjonProcessor(get(), get(), get(), get(), get(), get(), 3, env.frontendUrl) }
     single { ArbeidsgiverNotifikasjonProcessor(get(), get(), get(), env.frontendUrl, get()) }
-    single { ArbeidsgiverOppdaterNotifikasjonProcessor(get(), get()) }
+    single { ArbeidsgiverOppdaterNotifikasjonProcessor(get(), get(), get(), get()) }
     single { PdlService(get()) }
 
     single { MockBrregClient() } bind BrregClient::class

--- a/src/main/kotlin/no/nav/helse/fritakagp/koin/ProdKoinProfile.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/koin/ProdKoinProfile.kt
@@ -143,7 +143,7 @@ fun prodConfig(env: Env.Prod): Module = module {
 
     single { BrukernotifikasjonProcessor(get(), get(), get(), get(), get(), get(), 4, env.frontendUrl) }
     single { ArbeidsgiverNotifikasjonProcessor(get(), get(), get(), env.frontendUrl, get()) }
-    single { ArbeidsgiverOppdaterNotifikasjonProcessor(get(), get()) }
+    single { ArbeidsgiverOppdaterNotifikasjonProcessor(get(), get(), get(), get()) }
     single { PdlService(get()) }
 
     single { BrregClientImpl(get(), env.brregUrl) } bind BrregClient::class

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/arbeidsgivernotifikasjon/ArbeidsgiverOppdaterNotifikasjonProcessor.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/arbeidsgivernotifikasjon/ArbeidsgiverOppdaterNotifikasjonProcessor.kt
@@ -45,7 +45,7 @@ class ArbeidsgiverOppdaterNotifikasjonProcessor(
             arbeidsgiverNotifikasjonKlient.nyStatusSakByGrupperingsid(
                 grupperingsid = jobbData.skjemaId.toString(),
                 merkelapp = "Fritak arbeidsgiverperiode",
-                nyStatus = SaksStatus.MOTTATT,
+                nyStatus = SaksStatus.UNDER_BEHANDLING,
                 tidspunkt = tidspunkt.atOffset(ZoneOffset.of("+1")).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
             )
         }

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/arbeidsgivernotifikasjon/ArbeidsgiverOppdaterNotifikasjonProcessor.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/arbeidsgivernotifikasjon/ArbeidsgiverOppdaterNotifikasjonProcessor.kt
@@ -45,7 +45,7 @@ class ArbeidsgiverOppdaterNotifikasjonProcessor(
             arbeidsgiverNotifikasjonKlient.nyStatusSakByGrupperingsid(
                 grupperingsid = jobbData.skjemaId.toString(),
                 merkelapp = "Fritak arbeidsgiverperiode",
-                nyStatus = SaksStatus.UNDER_BEHANDLING,
+                nyStatus = SaksStatus.MOTTATT,
                 tidspunkt = tidspunkt.atOffset(ZoneOffset.of("+1")).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
             )
         }

--- a/src/test/kotlin/no/nav/helse/GravidTestData.kt
+++ b/src/test/kotlin/no/nav/helse/GravidTestData.kt
@@ -12,6 +12,7 @@ import no.nav.helse.fritakagp.domain.Tiltak
 import no.nav.helse.fritakagp.web.api.resreq.GravidKravRequest
 import no.nav.helse.fritakagp.web.api.resreq.GravidSoknadRequest
 import java.time.LocalDate
+import java.time.LocalDateTime
 
 object GravidTestData {
     val validNavn = "Personliga Person"
@@ -207,6 +208,7 @@ aąbcćdeęfghijlłmnńoóprsśtuwź
     )
 
     val gravidKrav = GravidKrav(
+        opprettet = LocalDateTime.of(2023, 12, 24, 10, 0),
         sendtAv = validIdentitetsnummer,
         virksomhetsnummer = validOrgNr,
 

--- a/src/test/kotlin/no/nav/helse/KroniskTestData.kt
+++ b/src/test/kotlin/no/nav/helse/KroniskTestData.kt
@@ -10,6 +10,7 @@ import no.nav.helse.fritakagp.domain.KroniskSoeknad
 import no.nav.helse.fritakagp.web.api.resreq.KroniskKravRequest
 import no.nav.helse.fritakagp.web.api.resreq.KroniskSoknadRequest
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import kotlin.random.Random
 
@@ -102,6 +103,7 @@ object KroniskTestData {
     )
 
     val kroniskKrav = KroniskKrav(
+        opprettet = LocalDateTime.of(2023, 12, 24, 10, 0),
         sendtAv = validIdentitetsnummer,
         virksomhetsnummer = validOrgNr,
         identitetsnummer = validIdentitetsnummer,

--- a/src/test/kotlin/no/nav/helse/fritakagp/processing/arbeidsgivernotifikasjon/ArbeidsgiverOppdaterNotifikasjonProcessorTest.kt
+++ b/src/test/kotlin/no/nav/helse/fritakagp/processing/arbeidsgivernotifikasjon/ArbeidsgiverOppdaterNotifikasjonProcessorTest.kt
@@ -56,12 +56,12 @@ class ArbeidsgiverOppdaterNotifikasjonProcessorTest {
     @Test
     fun `Oppdaterer sak mot arbeidsgiver-notifikasjoner for gravidKrav`() {
         prosessor.prosesser(gravidJobb)
-        coVerify(exactly = 1) { arbeidsgiverNotifikasjonKlient.nyStatusSakByGrupperingsid(gravidKrav.id.toString(), any(), SaksStatus.MOTTATT, "2023-12-24T10:00:00+01:00") }
+        coVerify(exactly = 1) { arbeidsgiverNotifikasjonKlient.nyStatusSakByGrupperingsid(gravidKrav.id.toString(), any(), SaksStatus.UNDER_BEHANDLING, "2023-12-24T10:00:00+01:00") }
     }
 
     @Test
     fun `Oppdaterer sak mot arbeidsgiver-notifikasjoner for kroniskKrav`() {
         prosessor.prosesser(kroniskJobb)
-        coVerify(exactly = 1) { arbeidsgiverNotifikasjonKlient.nyStatusSakByGrupperingsid(kroniskKrav.id.toString(), any(), SaksStatus.MOTTATT, "2023-12-24T10:00:00+01:00") }
+        coVerify(exactly = 1) { arbeidsgiverNotifikasjonKlient.nyStatusSakByGrupperingsid(kroniskKrav.id.toString(), any(), SaksStatus.UNDER_BEHANDLING, "2023-12-24T10:00:00+01:00") }
     }
 }

--- a/src/test/kotlin/no/nav/helse/fritakagp/processing/arbeidsgivernotifikasjon/ArbeidsgiverOppdaterNotifikasjonProcessorTest.kt
+++ b/src/test/kotlin/no/nav/helse/fritakagp/processing/arbeidsgivernotifikasjon/ArbeidsgiverOppdaterNotifikasjonProcessorTest.kt
@@ -56,12 +56,12 @@ class ArbeidsgiverOppdaterNotifikasjonProcessorTest {
     @Test
     fun `Oppdaterer sak mot arbeidsgiver-notifikasjoner for gravidKrav`() {
         prosessor.prosesser(gravidJobb)
-        coVerify(exactly = 1) { arbeidsgiverNotifikasjonKlient.nyStatusSakByGrupperingsid(gravidKrav.id.toString(), any(), SaksStatus.UNDER_BEHANDLING, "2023-12-24T10:00:00+01:00") }
+        coVerify(exactly = 1) { arbeidsgiverNotifikasjonKlient.nyStatusSakByGrupperingsid(gravidKrav.id.toString(), any(), SaksStatus.MOTTATT, "2023-12-24T10:00:00+01:00") }
     }
 
     @Test
     fun `Oppdaterer sak mot arbeidsgiver-notifikasjoner for kroniskKrav`() {
         prosessor.prosesser(kroniskJobb)
-        coVerify(exactly = 1) { arbeidsgiverNotifikasjonKlient.nyStatusSakByGrupperingsid(kroniskKrav.id.toString(), any(), SaksStatus.UNDER_BEHANDLING, "2023-12-24T10:00:00+01:00") }
+        coVerify(exactly = 1) { arbeidsgiverNotifikasjonKlient.nyStatusSakByGrupperingsid(kroniskKrav.id.toString(), any(), SaksStatus.MOTTATT, "2023-12-24T10:00:00+01:00") }
     }
 }


### PR DESCRIPTION
La forrige utgave av ArbeidsgiverOppdaterNotifikasjonProcessor rett tilbake på main siden den allerede var godkjent - og for å gjøre denne diffen mindre / enklere

Merk at oppdateringen fra klienten ikke funker mot fager enda, de jobber med saken - når dette er klart og testet OK i dev, kan man etter deploy rekjøre alle bakgrunnsjobber fra forrige oppdaterstatus-kjøring ala dette:  

update bakgrunnsjobb
 set status = 'OPPRETTET', kjoeretid = '2023-11-20 12:00:00'
 where type = 'arbeidsgiveroppdaternotifikasjon'
and status = 'OK';