### PR TITLE
Endre Krav - ny håndtering

### DIFF
--- a/src/main/kotlin/no/nav/helse/fritakagp/App.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/App.kt
@@ -18,6 +18,7 @@ import no.nav.helse.fritakagp.processing.gravid.krav.GravidKravSlettProcessor
 import no.nav.helse.fritakagp.processing.gravid.krav.OpprettRobotOppgaveGravidProcessor
 import no.nav.helse.fritakagp.processing.gravid.soeknad.GravidSoeknadKvitteringProcessor
 import no.nav.helse.fritakagp.processing.gravid.soeknad.GravidSoeknadProcessor
+import no.nav.helse.fritakagp.processing.kronisk.krav.KroniskKravEndreProcessor
 import no.nav.helse.fritakagp.processing.kronisk.krav.KroniskKravKvitteringProcessor
 import no.nav.helse.fritakagp.processing.kronisk.krav.KroniskKravProcessor
 import no.nav.helse.fritakagp.processing.kronisk.krav.KroniskKravSlettProcessor
@@ -99,6 +100,7 @@ class FritakAgpApplication(val port: Int = 8080, val runAsDeamon: Boolean = true
             registrer(get<KroniskKravProcessor>())
             registrer(get<KroniskKravKvitteringProcessor>())
             registrer(get<KroniskKravSlettProcessor>())
+            registrer(get<KroniskKravEndreProcessor>())
             registrer(get<OpprettRobotOppgaveKroniskProcessor>())
 
             registrer(get<BrukernotifikasjonProcessor>())

--- a/src/main/kotlin/no/nav/helse/fritakagp/App.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/App.kt
@@ -12,6 +12,7 @@ import no.nav.helse.fritakagp.koin.profileModules
 import no.nav.helse.fritakagp.processing.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjonProcessor
 import no.nav.helse.fritakagp.processing.arbeidsgivernotifikasjon.ArbeidsgiverOppdaterNotifikasjonProcessor
 import no.nav.helse.fritakagp.processing.brukernotifikasjon.BrukernotifikasjonProcessor
+import no.nav.helse.fritakagp.processing.gravid.krav.GravidKravEndreProcessor
 import no.nav.helse.fritakagp.processing.gravid.krav.GravidKravKvitteringProcessor
 import no.nav.helse.fritakagp.processing.gravid.krav.GravidKravProcessor
 import no.nav.helse.fritakagp.processing.gravid.krav.GravidKravSlettProcessor
@@ -92,6 +93,7 @@ class FritakAgpApplication(val port: Int = 8080, val runAsDeamon: Boolean = true
             registrer(get<GravidKravProcessor>())
             registrer(get<GravidKravKvitteringProcessor>())
             registrer(get<GravidKravSlettProcessor>())
+            registrer(get<GravidKravEndreProcessor>())
             registrer(get<OpprettRobotOppgaveGravidProcessor>())
 
             registrer(get<KroniskSoeknadProcessor>())

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/GravidKrav.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/GravidKrav.kt
@@ -32,6 +32,7 @@ data class GravidKrav(
 
     var status: KravStatus = KravStatus.OPPRETTET,
     var aarsakEndring: String? = null,
+    var endretTilId: UUID? = null,
     var endretDato: LocalDateTime? = null,
 
     var arbeidsgiverSakId: String? = null,

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/GravidKrav.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/GravidKrav.kt
@@ -67,6 +67,7 @@ data class GravidKrav(
 
 enum class KravStatus {
     OPPRETTET,
+    OPPDATERT,
     ENDRET,
     SLETTET
 }

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskKrav.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskKrav.kt
@@ -32,6 +32,7 @@ data class KroniskKrav(
 
     var status: KravStatus = KravStatus.OPPRETTET,
     var aarsakEndring: String? = null,
+    var endretTilId: UUID? = null,
     var endretDato: LocalDateTime? = null,
 
     var arbeidsgiverSakId: String? = null,

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/utils.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/utils.kt
@@ -107,6 +107,7 @@ fun generereEndretKroniskKravBeskrivelse(krav: KroniskKrav, desc: String): Strin
         appendLine("Endret krav med JournalpostId: ${krav.journalpostId}")
         appendLine("Person (FNR): ${krav.identitetsnummer}")
         appendLine("Arbeidsgiver oppgitt i krav: ${krav.virksomhetsnavn} (${krav.virksomhetsnummer})")
+        appendLine("Antall lønnsdager: ${krav.antallDager}")
         appendLine("Periode:")
         appendLine(genererePeriodeTable(krav.perioder))
     }

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/utils.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/utils.kt
@@ -143,8 +143,8 @@ fun genererePeriodeTable(perioder: List<Arbeidsgiverperiode>): String {
         for (p in perioder.sortedBy { it.fom }) {
             val gradering = (p.gradering * 100).toString() + "%"
             row(
-                p.fom,
-                p.tom,
+                DATE_FORMAT.format(p.fom),
+                DATE_FORMAT.format(p.tom),
                 gradering,
                 p.antallDagerMedRefusjon,
                 p.månedsinntekt.roundToInt().toString(),

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/utils.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/utils.kt
@@ -113,7 +113,19 @@ fun generereEndretKroniskKravBeskrivelse(krav: KroniskKrav, desc: String): Strin
     }
 }
 
-fun generereGravidkKravBeskrivelse(krav: GravidKrav, desc: String): String {
+fun generereEndretGravidKravBeskrivelse(krav: GravidKrav, desc: String): String {
+    return buildString {
+        appendLine(desc)
+        appendLine("Endret krav mottatt: ${TIMESTAMP_FORMAT.format(krav.opprettet)}")
+        appendLine("Referansenummer: ${krav.referansenummer}")
+        appendLine("Person (FNR): ${krav.identitetsnummer}")
+        appendLine("Arbeidsgiver oppgitt i krav: ${krav.virksomhetsnavn} (${krav.virksomhetsnummer})")
+        appendLine("Antall lønnsdager: ${krav.antallDager}")
+        appendLine("Periode:")
+        appendLine(genererePeriodeTable(krav.perioder))
+    }
+}
+fun generereGravidKravBeskrivelse(krav: GravidKrav, desc: String): String {
     return buildString {
         appendLine(desc)
         appendLine("Mottatt: ${krav.opprettet.format(TIMESTAMP_FORMAT)}")

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/utils.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/utils.kt
@@ -100,6 +100,18 @@ fun generereSlettKroniskKravBeskrivelse(krav: KroniskKrav, desc: String): String
     }
 }
 
+fun generereEndretKroniskKravBeskrivelse(krav: KroniskKrav, desc: String): String {
+    return buildString {
+        appendLine(desc)
+        appendLine("Endret krav mottatt: ${TIMESTAMP_FORMAT.format(krav.opprettet)}")
+        appendLine("Endret krav med JournalpostId: ${krav.journalpostId}")
+        appendLine("Person (FNR): ${krav.identitetsnummer}")
+        appendLine("Arbeidsgiver oppgitt i krav: ${krav.virksomhetsnavn} (${krav.virksomhetsnummer})")
+        appendLine("Periode:")
+        appendLine(genererePeriodeTable(krav.perioder))
+    }
+}
+
 fun generereGravidkKravBeskrivelse(krav: GravidKrav, desc: String): String {
     return buildString {
         appendLine(desc)
@@ -131,8 +143,8 @@ fun genererePeriodeTable(perioder: List<Arbeidsgiverperiode>): String {
         for (p in perioder.sortedBy { it.fom }) {
             val gradering = (p.gradering * 100).toString() + "%"
             row(
-                p.fom.atStartOfDay(),
-                p.tom.atStartOfDay(),
+                p.fom,
+                p.tom,
                 gradering,
                 p.antallDagerMedRefusjon,
                 p.månedsinntekt.roundToInt().toString(),

--- a/src/main/kotlin/no/nav/helse/fritakagp/koin/LocalKoinProfile.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/koin/LocalKoinProfile.kt
@@ -35,6 +35,7 @@ import no.nav.helse.fritakagp.processing.gravid.soeknad.GravidSoeknadKvitteringS
 import no.nav.helse.fritakagp.processing.gravid.soeknad.GravidSoeknadKvitteringSenderDummy
 import no.nav.helse.fritakagp.processing.gravid.soeknad.GravidSoeknadPDFGenerator
 import no.nav.helse.fritakagp.processing.gravid.soeknad.GravidSoeknadProcessor
+import no.nav.helse.fritakagp.processing.kronisk.krav.KroniskKravEndreProcessor
 import no.nav.helse.fritakagp.processing.kronisk.krav.KroniskKravKvitteringProcessor
 import no.nav.helse.fritakagp.processing.kronisk.krav.KroniskKravKvitteringSender
 import no.nav.helse.fritakagp.processing.kronisk.krav.KroniskKravKvitteringSenderDummy
@@ -74,6 +75,7 @@ fun localConfig(env: Env.Local): Module = module {
     single { KroniskSoeknadProcessor(get(), get(), get(), get(), get(), KroniskSoeknadPDFGenerator(), get(), get(), get()) }
     single { KroniskKravProcessor(get(), get(), get(), get(), get(), KroniskKravPDFGenerator(), get(), get(), get(), get()) }
     single { KroniskKravSlettProcessor(get(), get(), get(), get(), KroniskKravPDFGenerator(), get(), get()) }
+    single { KroniskKravEndreProcessor(get(), get(), get(), get(), KroniskKravPDFGenerator(), get(), get()) }
     single { OpprettRobotOppgaveKroniskProcessor(get(), get(), get(), get(), get()) }
 
     single { GravidSoeknadKvitteringSenderDummy() } bind GravidSoeknadKvitteringSender::class

--- a/src/main/kotlin/no/nav/helse/fritakagp/koin/LocalKoinProfile.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/koin/LocalKoinProfile.kt
@@ -23,6 +23,7 @@ import no.nav.helse.fritakagp.integration.altinn.AltinnAuthorizer
 import no.nav.helse.fritakagp.integration.altinn.DefaultAltinnAuthorizer
 import no.nav.helse.fritakagp.processing.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjonProcessor
 import no.nav.helse.fritakagp.processing.brukernotifikasjon.BrukernotifikasjonProcessor
+import no.nav.helse.fritakagp.processing.gravid.krav.GravidKravEndreProcessor
 import no.nav.helse.fritakagp.processing.gravid.krav.GravidKravKvitteringProcessor
 import no.nav.helse.fritakagp.processing.gravid.krav.GravidKravKvitteringSender
 import no.nav.helse.fritakagp.processing.gravid.krav.GravidKravKvitteringSenderDummy
@@ -72,6 +73,7 @@ fun localConfig(env: Env.Local): Module = module {
     single { GravidSoeknadProcessor(get(), get(), get(), get(), get(), GravidSoeknadPDFGenerator(), get(), get(), get()) }
     single { GravidKravProcessor(get(), get(), get(), get(), get(), GravidKravPDFGenerator(), get(), get(), get()) }
     single { GravidKravSlettProcessor(get(), get(), get(), get(), GravidKravPDFGenerator(), get(), get()) }
+    single { GravidKravEndreProcessor(get(), get(), get(), get(), GravidKravPDFGenerator(), get(), get()) }
     single { KroniskSoeknadProcessor(get(), get(), get(), get(), get(), KroniskSoeknadPDFGenerator(), get(), get(), get()) }
     single { KroniskKravProcessor(get(), get(), get(), get(), get(), KroniskKravPDFGenerator(), get(), get(), get(), get()) }
     single { KroniskKravSlettProcessor(get(), get(), get(), get(), KroniskKravPDFGenerator(), get(), get()) }

--- a/src/main/kotlin/no/nav/helse/fritakagp/koin/PreprodKoinProfile.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/koin/PreprodKoinProfile.kt
@@ -28,6 +28,7 @@ import no.nav.helse.fritakagp.processing.arbeidsgivernotifikasjon.ArbeidsgiverNo
 import no.nav.helse.fritakagp.processing.arbeidsgivernotifikasjon.ArbeidsgiverOppdaterNotifikasjonProcessor
 import no.nav.helse.fritakagp.processing.brukernotifikasjon.BrukernotifikasjonProcessor
 import no.nav.helse.fritakagp.processing.gravid.krav.GravidKravAltinnKvitteringSender
+import no.nav.helse.fritakagp.processing.gravid.krav.GravidKravEndreProcessor
 import no.nav.helse.fritakagp.processing.gravid.krav.GravidKravKvitteringProcessor
 import no.nav.helse.fritakagp.processing.gravid.krav.GravidKravKvitteringSender
 import no.nav.helse.fritakagp.processing.gravid.krav.GravidKravPDFGenerator
@@ -82,6 +83,7 @@ fun preprodConfig(env: Env.Preprod): Module = module {
     single { GravidSoeknadProcessor(get(), get(), get(), get(), get(), GravidSoeknadPDFGenerator(), get(), get(), get()) }
     single { GravidKravProcessor(get(), get(), get(), get(), get(), GravidKravPDFGenerator(), get(), get(), get()) }
     single { GravidKravSlettProcessor(get(), get(), get(), get(), GravidKravPDFGenerator(), get(), get()) }
+    single { GravidKravEndreProcessor(get(), get(), get(), get(), GravidKravPDFGenerator(), get(), get()) }
     single { OpprettRobotOppgaveKroniskProcessor(get(), get(), get(), get(), get()) }
 
     single { KroniskSoeknadProcessor(get(), get(), get(), get(), get(), KroniskSoeknadPDFGenerator(), get(), get(), get()) }

--- a/src/main/kotlin/no/nav/helse/fritakagp/koin/PreprodKoinProfile.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/koin/PreprodKoinProfile.kt
@@ -40,6 +40,7 @@ import no.nav.helse.fritakagp.processing.gravid.soeknad.GravidSoeknadKvitteringS
 import no.nav.helse.fritakagp.processing.gravid.soeknad.GravidSoeknadPDFGenerator
 import no.nav.helse.fritakagp.processing.gravid.soeknad.GravidSoeknadProcessor
 import no.nav.helse.fritakagp.processing.kronisk.krav.KroniskKravAltinnKvitteringSender
+import no.nav.helse.fritakagp.processing.kronisk.krav.KroniskKravEndreProcessor
 import no.nav.helse.fritakagp.processing.kronisk.krav.KroniskKravKvitteringProcessor
 import no.nav.helse.fritakagp.processing.kronisk.krav.KroniskKravKvitteringSender
 import no.nav.helse.fritakagp.processing.kronisk.krav.KroniskKravPDFGenerator
@@ -86,6 +87,7 @@ fun preprodConfig(env: Env.Preprod): Module = module {
     single { KroniskSoeknadProcessor(get(), get(), get(), get(), get(), KroniskSoeknadPDFGenerator(), get(), get(), get()) }
     single { KroniskKravProcessor(get(), get(), get(), get(), get(), KroniskKravPDFGenerator(), get(), get(), get(), get()) }
     single { KroniskKravSlettProcessor(get(), get(), get(), get(), KroniskKravPDFGenerator(), get(), get()) }
+    single { KroniskKravEndreProcessor(get(), get(), get(), get(), KroniskKravPDFGenerator(), get(), get()) }
     single { OpprettRobotOppgaveGravidProcessor(get(), get(), get(), get(), get()) }
 
     single { Clients.iCorrespondenceExternalBasic(env.altinnMeldingUrl) }

--- a/src/main/kotlin/no/nav/helse/fritakagp/koin/ProdKoinProfile.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/koin/ProdKoinProfile.kt
@@ -28,6 +28,7 @@ import no.nav.helse.fritakagp.processing.arbeidsgivernotifikasjon.ArbeidsgiverNo
 import no.nav.helse.fritakagp.processing.arbeidsgivernotifikasjon.ArbeidsgiverOppdaterNotifikasjonProcessor
 import no.nav.helse.fritakagp.processing.brukernotifikasjon.BrukernotifikasjonProcessor
 import no.nav.helse.fritakagp.processing.gravid.krav.GravidKravAltinnKvitteringSender
+import no.nav.helse.fritakagp.processing.gravid.krav.GravidKravEndreProcessor
 import no.nav.helse.fritakagp.processing.gravid.krav.GravidKravKvitteringProcessor
 import no.nav.helse.fritakagp.processing.gravid.krav.GravidKravKvitteringSender
 import no.nav.helse.fritakagp.processing.gravid.krav.GravidKravPDFGenerator
@@ -40,6 +41,7 @@ import no.nav.helse.fritakagp.processing.gravid.soeknad.GravidSoeknadKvitteringS
 import no.nav.helse.fritakagp.processing.gravid.soeknad.GravidSoeknadPDFGenerator
 import no.nav.helse.fritakagp.processing.gravid.soeknad.GravidSoeknadProcessor
 import no.nav.helse.fritakagp.processing.kronisk.krav.KroniskKravAltinnKvitteringSender
+import no.nav.helse.fritakagp.processing.kronisk.krav.KroniskKravEndreProcessor
 import no.nav.helse.fritakagp.processing.kronisk.krav.KroniskKravKvitteringProcessor
 import no.nav.helse.fritakagp.processing.kronisk.krav.KroniskKravKvitteringSender
 import no.nav.helse.fritakagp.processing.kronisk.krav.KroniskKravPDFGenerator
@@ -81,11 +83,13 @@ fun prodConfig(env: Env.Prod): Module = module {
     single { GravidSoeknadProcessor(get(), get(), get(), get(), get(), GravidSoeknadPDFGenerator(), get(), get(), get()) }
     single { GravidKravProcessor(get(), get(), get(), get(), get(), GravidKravPDFGenerator(), get(), get(), get()) }
     single { GravidKravSlettProcessor(get(), get(), get(), get(), GravidKravPDFGenerator(), get(), get()) }
+    single { GravidKravEndreProcessor(get(), get(), get(), get(), GravidKravPDFGenerator(), get(), get()) }
     single { OpprettRobotOppgaveGravidProcessor(get(), get(), get(), get(), get()) }
 
     single { KroniskSoeknadProcessor(get(), get(), get(), get(), get(), KroniskSoeknadPDFGenerator(), get(), get(), get()) }
     single { KroniskKravProcessor(get(), get(), get(), get(), get(), KroniskKravPDFGenerator(), get(), get(), get(), get()) }
     single { KroniskKravSlettProcessor(get(), get(), get(), get(), KroniskKravPDFGenerator(), get(), get()) }
+    single { KroniskKravEndreProcessor(get(), get(), get(), get(), KroniskKravPDFGenerator(), get(), get()) }
     single { OpprettRobotOppgaveKroniskProcessor(get(), get(), get(), get(), get()) }
 
     single { Clients.iCorrespondenceExternalBasic(env.altinnMeldingUrl) }

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/GravidKravPDFGenerator.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/GravidKravPDFGenerator.kt
@@ -34,10 +34,29 @@ class GravidKravPDFGenerator {
 
     fun lagPDF(krav: GravidKrav): ByteArray {
         val doc = PDDocument()
+        leggTilKrav(doc, krav, GravidKrav.tittel)
+        val out = ByteArrayOutputStream()
+        doc.save(out)
+        val ba = out.toByteArray()
+        doc.close()
+        return ba
+    }
+
+    fun lagEndringPdf(oppdatertKrav: GravidKrav, endretKrav: GravidKrav): ByteArray {
+        val doc = PDDocument()
+        leggTilKrav(doc, oppdatertKrav, "Endring ${GravidKrav.tittel}")
+        leggTilKrav(doc, endretKrav, "Tidligere ${GravidKrav.tittel}")
+        val out = ByteArrayOutputStream()
+        doc.save(out)
+        val ba = out.toByteArray()
+        doc.close()
+        return ba
+    }
+    fun leggTilKrav(doc: PDDocument, krav: GravidKrav, tittel: String) {
         val font = PDType0Font.load(doc, this::class.java.classLoader.getResource(FONT_NAME).openStream())
         var content = lagNySide(doc, font)
         content.setFont(font, FONT_SIZE + 4)
-        content.showText(GravidKrav.tittel)
+        content.showText(tittel)
         content.setFont(font, FONT_SIZE)
 
         content.writeTextWrapped("Mottatt: ${krav.opprettet.format(TIMESTAMP_FORMAT)}", 4)
@@ -73,13 +92,7 @@ class GravidKravPDFGenerator {
 
         content.endText()
         content.close()
-        val out = ByteArrayOutputStream()
-        doc.save(out)
-        val ba = out.toByteArray()
-        doc.close()
-        return ba
     }
-
     fun lagSlettingPDF(krav: GravidKrav): ByteArray {
         val doc = PDDocument()
         val font = PDType0Font.load(doc, this::class.java.classLoader.getResource(FONT_NAME).openStream())

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/GravidKravSlettProcessor.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/GravidKravSlettProcessor.kt
@@ -69,7 +69,7 @@ class GravidKravSlettProcessor(
     override fun stoppet(jobb: Bakgrunnsjobb) {
         val krav = getOrThrow(jobb)
         val oppgaveId = opprettFordelingsOppgave(krav)
-        logger.warn("Jobben ${jobb.uuid} feilet permanenet og resulterte i fordelignsoppgave $oppgaveId")
+        logger.warn("Jobben ${jobb.uuid} feilet permanent og resulterte i fordelingsoppgave $oppgaveId")
     }
 
     private fun updateAndLogOnFailure(krav: GravidKrav) {

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/OpprettRobotOppgaveGravidProcessor.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/OpprettRobotOppgaveGravidProcessor.kt
@@ -55,7 +55,7 @@ class OpprettRobotOppgaveGravidProcessor(
     }
 
     override fun stoppet(jobb: Bakgrunnsjobb) {
-        logger.warn("Jobben ${jobb.uuid} feilet permanenet")
+        logger.warn("Jobben ${jobb.uuid} feilet permanent")
     }
 
     private fun updateAndLogOnFailure(krav: GravidKrav) {

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/soeknad/GravidSoeknadProcessor.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/gravid/soeknad/GravidSoeknadProcessor.kt
@@ -122,7 +122,7 @@ class GravidSoeknadProcessor(
     override fun stoppet(jobb: Bakgrunnsjobb) {
         val soeknad = getSoeknadOrThrow(jobb)
         val oppgaveId = opprettFordelingsOppgave(soeknad)
-        logger.warn("Jobben ${jobb.uuid} feilet permanenet og resulterte i fordelignsoppgave $oppgaveId")
+        logger.warn("Jobben ${jobb.uuid} feilet permanent og resulterte i fordelingsoppgave $oppgaveId")
     }
 
     private fun getSoeknadOrThrow(jobb: Bakgrunnsjobb): GravidSoeknad {

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravEndreProcessor.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravEndreProcessor.kt
@@ -169,6 +169,8 @@ class KroniskKravEndreProcessor(
         val beskrivelse: String =
             buildString {
                 append(generereKroniskKravBeskrivelse(oppdatertKrav, "Endret: ${KroniskKrav.tittel}"))
+                appendLine()
+                appendLine()
                 append(generereEndretKroniskKravBeskrivelse(endretKrav, "Tidligere: ${KroniskKrav.tittel}"))
             }
         val request = OpprettOppgaveRequest(

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravEndreProcessor.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravEndreProcessor.kt
@@ -60,7 +60,7 @@ class KroniskKravEndreProcessor(
         }
     }
 
-    private fun getOrThrow(jobb: Bakgrunnsjobb): Pair<KroniskKrav,KroniskKrav> {
+    private fun getOrThrow(jobb: Bakgrunnsjobb): Pair<KroniskKrav, KroniskKrav> {
         val jobbData = om.readValue<KroniskKravProcessor.JobbData>(jobb.data)
         val endretKrav = kroniskKravRepo.getById(jobbData.id)
         requireNotNull(endretKrav) { "Jobben indikerte et endret krav med id ${jobb.data} men den kunne ikke finnes" }
@@ -110,7 +110,7 @@ class KroniskKravEndreProcessor(
         journalfoeringsTittel: String
     ): List<Dokument> {
         val base64EnkodetPdf = Base64.getEncoder().encodeToString(pdfGenerator.lagEndringPdf(oppdatertKrav, endretKrav))
-        val jsonOrginalDokument = Base64.getEncoder().encodeToString(om.writeValueAsBytes(listOf(endretKrav,oppdatertKrav)))
+        val jsonOrginalDokument = Base64.getEncoder().encodeToString(om.writeValueAsBytes(listOf(endretKrav, oppdatertKrav)))
         val dokumentListe = mutableListOf(
             Dokument(
                 dokumentVarianter = listOf(

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravEndreProcessor.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravEndreProcessor.kt
@@ -78,7 +78,7 @@ class KroniskKravEndreProcessor(
         val (endretKrav, oppdatertKrav) = getOrThrow(jobb)
 
         val oppgaveId = opprettFordelingsOppgave(oppdatertKrav, endretKrav)
-        logger.warn("Jobben ${jobb.uuid} feilet permanenet og resulterte i fordelignsoppgave $oppgaveId")
+        logger.warn("Jobben ${jobb.uuid} feilet permanent og resulterte i fordelingsoppgave $oppgaveId")
     }
 
     private fun updateAndLogOnFailure(krav: KroniskKrav) {

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravEndreProcessor.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravEndreProcessor.kt
@@ -53,6 +53,9 @@ class KroniskKravEndreProcessor(
         val (endretKrav, oppdatertKrav) = getOrThrow(jobb)
         logger.info("Endrer krav ${endretKrav.id} til ${oppdatertKrav.id}")
         try {
+            if (oppdatertKrav.virksomhetsnavn == null) {
+                oppdatertKrav.virksomhetsnavn = endretKrav.virksomhetsnavn
+            }
             oppdatertKrav.journalpostId = journalførOppdatering(oppdatertKrav, endretKrav)
             oppdatertKrav.oppgaveId = opprettOppgave(oppdatertKrav, endretKrav)
         } finally {

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravPDFGenerator.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravPDFGenerator.kt
@@ -32,12 +32,11 @@ class KroniskKravPDFGenerator {
         return content
     }
 
-    fun lagPDF(krav: KroniskKrav): ByteArray {
-        val doc = PDDocument()
+    fun leggTilKrav(doc: PDDocument, krav: KroniskKrav, tittel: String){
         val font = PDType0Font.load(doc, this::class.java.classLoader.getResource(FONT_NAME).openStream())
         var content = lagNySide(doc, font)
         content.setFont(font, FONT_SIZE + 4)
-        content.showText(KroniskKrav.tittel)
+        content.showText(tittel)
         content.setFont(font, FONT_SIZE)
 
         content.writeTextWrapped("Mottatt: ${krav.opprettet.format(TIMESTAMP_FORMAT)}", 4)
@@ -71,9 +70,25 @@ class KroniskKravPDFGenerator {
                     writeTextWrapped("")
                 }
             }
-
         content.endText()
         content.close()
+    }
+
+    fun lagPDF(krav: KroniskKrav): ByteArray {
+        val doc = PDDocument()
+        leggTilKrav(doc, krav, KroniskKrav.tittel)
+        val out = ByteArrayOutputStream()
+        doc.save(out)
+        val ba = out.toByteArray()
+        doc.close()
+        return ba
+    }
+    fun lagEndringPdf(oppdatertKrav: KroniskKrav, endretKrav: KroniskKrav): ByteArray {
+        val doc = PDDocument()
+        leggTilKrav(doc, oppdatertKrav, "Endring ${KroniskKrav.tittel}")
+
+        //TODO: nytt navn på tittel
+        leggTilKrav(doc, endretKrav, "Tidligere ${KroniskKrav.tittel}")
         val out = ByteArrayOutputStream()
         doc.save(out)
         val ba = out.toByteArray()

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravPDFGenerator.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravPDFGenerator.kt
@@ -87,7 +87,6 @@ class KroniskKravPDFGenerator {
         val doc = PDDocument()
         leggTilKrav(doc, oppdatertKrav, "Endring ${KroniskKrav.tittel}")
 
-        // TODO: nytt navn på tittel
         leggTilKrav(doc, endretKrav, "Tidligere ${KroniskKrav.tittel}")
         val out = ByteArrayOutputStream()
         doc.save(out)

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravPDFGenerator.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravPDFGenerator.kt
@@ -32,7 +32,7 @@ class KroniskKravPDFGenerator {
         return content
     }
 
-    fun leggTilKrav(doc: PDDocument, krav: KroniskKrav, tittel: String){
+    fun leggTilKrav(doc: PDDocument, krav: KroniskKrav, tittel: String) {
         val font = PDType0Font.load(doc, this::class.java.classLoader.getResource(FONT_NAME).openStream())
         var content = lagNySide(doc, font)
         content.setFont(font, FONT_SIZE + 4)
@@ -87,7 +87,7 @@ class KroniskKravPDFGenerator {
         val doc = PDDocument()
         leggTilKrav(doc, oppdatertKrav, "Endring ${KroniskKrav.tittel}")
 
-        //TODO: nytt navn på tittel
+        // TODO: nytt navn på tittel
         leggTilKrav(doc, endretKrav, "Tidligere ${KroniskKrav.tittel}")
         val out = ByteArrayOutputStream()
         doc.save(out)

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravProcessor.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravProcessor.kt
@@ -107,7 +107,7 @@ class KroniskKravProcessor(
     override fun stoppet(jobb: Bakgrunnsjobb) {
         val krav = getOrThrow(jobb)
         val oppgaveId = opprettFordelingsOppgave(krav)
-        logger.warn("Jobben ${jobb.uuid} feilet permanenet og resulterte i fordelignsoppgave $oppgaveId")
+        logger.warn("Jobben ${jobb.uuid} feilet permanent og resulterte i fordelingsoppgave $oppgaveId")
     }
 
     private fun updateAndLogOnFailure(krav: KroniskKrav) {

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravSlettProcessor.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/KroniskKravSlettProcessor.kt
@@ -69,7 +69,7 @@ class KroniskKravSlettProcessor(
     override fun stoppet(jobb: Bakgrunnsjobb) {
         val krav = getOrThrow(jobb)
         val oppgaveId = opprettFordelingsOppgave(krav)
-        logger.warn("Jobben ${jobb.uuid} feilet permanenet og resulterte i fordelignsoppgave $oppgaveId")
+        logger.warn("Jobben ${jobb.uuid} feilet permanent og resulterte i fordelingsoppgave $oppgaveId")
     }
 
     private fun updateAndLogOnFailure(krav: KroniskKrav) {

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/OpprettRobotOppgaveKroniskProcessor.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/krav/OpprettRobotOppgaveKroniskProcessor.kt
@@ -60,7 +60,7 @@ class OpprettRobotOppgaveKroniskProcessor(
     }
 
     override fun stoppet(jobb: Bakgrunnsjobb) {
-        logger.warn("Jobben ${jobb.uuid} feilet permanenet")
+        logger.warn("Jobben ${jobb.uuid} feilet permanent")
     }
 
     private fun updateAndLogOnFailure(krav: KroniskKrav) {

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/soeknad/KroniskSoeknadProcessor.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/kronisk/soeknad/KroniskSoeknadProcessor.kt
@@ -94,7 +94,7 @@ class KroniskSoeknadProcessor(
     override fun stoppet(jobb: Bakgrunnsjobb) {
         val soeknad = getSoeknadOrThrow(jobb)
         val oppgaveId = opprettFordelingsOppgave(soeknad)
-        logger.warn("Jobben ${jobb.uuid} feilet permanenet og resulterte i fordelignsoppgave $oppgaveId")
+        logger.warn("Jobben ${jobb.uuid} feilet permanent og resulterte i fordelingsoppgave $oppgaveId")
     }
 
     private fun getSoeknadOrThrow(jobb: Bakgrunnsjobb): KroniskSoeknad {

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/KroniskRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/KroniskRoutes.kt
@@ -230,15 +230,11 @@ fun Route.kroniskRoutes(
                     runBlocking { arbeidsgiverNotifikasjonKlient.hardDeleteSak(it) }
                 }
 
-                logger.info("KKPa: Oppdater gammelt krav til slettet i db.")
+                logger.info("KKPa: Oppdater gammelt krav til status: ${KravStatus.ENDRET} i db.")
                 kroniskKravRepo.update(endretKrav)
-               /* bakgunnsjobbService.opprettJobb<KroniskKravSlettProcessor>(
-                    maksAntallForsoek = 10,
-                    data = om.writeValueAsString(KroniskKravProcessor.JobbData(kravTilSletting.id))
-                )*/
 
                 // Oppretter nytt krav
-                logger.info("KKPa: Legg til nytt krav i db.")
+                logger.info("KKPa: Legg til nytt krav i db med status: ${KravStatus.OPPDATERT}.")
                 kroniskKravRepo.insert(kravTilOppdatering)
                 bakgunnsjobbService.opprettJobb<KroniskKravEndreProcessor>(
                     maksAntallForsoek = 10,

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/KroniskRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/KroniskRoutes.kt
@@ -224,8 +224,6 @@ fun Route.kroniskRoutes(
                 endretKrav.endretDato = LocalDateTime.now()
                 endretKrav.endretTilId = kravTilOppdatering.id
 
-
-
                 // Sletter gammelt krav
                 logger.info("KKPa: Slett sak om gammelt krav i arbeidsgivernotifikasjon.")
                 endretKrav.arbeidsgiverSakId?.let {

--- a/src/test/kotlin/no/nav/helse/GravidTestData.kt
+++ b/src/test/kotlin/no/nav/helse/GravidTestData.kt
@@ -228,6 +228,8 @@ aąbcćdeęfghijlłmnńoóprsśtuwź
         navn = validNavn
     )
 
+    val gravidEndretKrav = gravidKrav.copy(antallDager = 6)
+
     val gravidLangtKrav = GravidKrav(
         sendtAv = validIdentitetsnummer,
         virksomhetsnummer = validOrgNr,

--- a/src/test/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/GravidKravEndreProcessorTest.kt
+++ b/src/test/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/GravidKravEndreProcessorTest.kt
@@ -1,0 +1,95 @@
+package no.nav.helse.fritakagp.processing.gravid.krav
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import no.nav.helse.GravidTestData
+import no.nav.helse.arbeidsgiver.integrasjoner.oppgave2.OppgaveKlient
+import no.nav.helse.fritakagp.customObjectMapper
+import no.nav.helse.fritakagp.db.GravidKravRepository
+import no.nav.helse.fritakagp.domain.GravidKrav
+import no.nav.helse.fritakagp.integration.brreg.BrregClient
+import no.nav.helse.fritakagp.integration.gcp.BucketStorage
+import no.nav.helse.fritakagp.processing.BakgrunnsJobbUtils.emptyJob
+import no.nav.helse.fritakagp.processing.BakgrunnsJobbUtils.testJob
+import no.nav.helse.fritakagp.service.PdlService
+import no.nav.helsearbeidsgiver.dokarkiv.DokArkivClient
+import no.nav.helsearbeidsgiver.dokarkiv.domene.OpprettOgFerdigstillResponse
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.io.IOException
+import java.util.UUID
+import kotlin.test.assertEquals
+
+class GravidKravEndreProcessorTest {
+
+    val joarkMock = mockk<DokArkivClient>(relaxed = true)
+    val oppgaveMock = mockk<OppgaveKlient>(relaxed = true)
+    val repositoryMock = mockk<GravidKravRepository>(relaxed = true)
+    val pdlServiceMock = mockk<PdlService>(relaxed = true)
+    val objectMapper = customObjectMapper()
+    val pdfGeneratorMock = mockk<GravidKravPDFGenerator>(relaxed = true)
+    val bucketStorageMock = mockk<BucketStorage>(relaxed = true)
+    val berregServiceMock = mockk<BrregClient>(relaxed = true)
+
+    val prosessor = GravidKravEndreProcessor(repositoryMock, joarkMock, oppgaveMock, pdlServiceMock, pdfGeneratorMock, objectMapper, bucketStorageMock)
+    lateinit var endretKrav: GravidKrav
+    lateinit var oppdatertKrav: GravidKrav
+
+    private val oppgaveId = 9999
+    private val arkivReferanse = "12345"
+    private var jobb = emptyJob()
+
+    @BeforeEach
+    fun setup() {
+        val uuid = UUID.randomUUID()
+        endretKrav = GravidTestData.gravidEndretKrav.copy(endretTilId = uuid)
+        oppdatertKrav = GravidTestData.gravidKrav.copy(id = uuid)
+        jobb = testJob(objectMapper.writeValueAsString(GravidKravProcessor.JobbData(endretKrav.id)))
+        every { repositoryMock.getById(endretKrav.id) } returns endretKrav
+        every { repositoryMock.getById(endretKrav.endretTilId!!) } returns oppdatertKrav
+        every { bucketStorageMock.getDocAsString(any()) } returns null
+        every { pdlServiceMock.hentAktoerId(endretKrav.identitetsnummer) } returns "aktør-id"
+        coEvery { joarkMock.opprettOgFerdigstillJournalpost(any(), any(), any(), any(), any(), any(), any()) } returns OpprettOgFerdigstillResponse(arkivReferanse, true, null, emptyList())
+        coEvery { oppgaveMock.opprettOppgave(any(), any()) } returns GravidTestData.gravidOpprettOppgaveResponse.copy(id = oppgaveId)
+        coEvery { berregServiceMock.getVirksomhetsNavn(endretKrav.virksomhetsnummer) } returns "Stark Industries"
+    }
+
+    @Test
+    fun `skal journalføre, opprette oppgave og oppdatere søknaden i databasen`() {
+        prosessor.prosesser(jobb)
+
+        assertThat(oppdatertKrav.journalpostId).isEqualTo(arkivReferanse)
+        assertThat(oppdatertKrav.oppgaveId).isEqualTo(oppgaveId.toString())
+
+        coVerify(exactly = 1) { joarkMock.opprettOgFerdigstillJournalpost(any(), any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 1) {
+            oppgaveMock.opprettOppgave(
+                withArg {
+                    assertEquals("BEH_REF", it.oppgavetype)
+                },
+                any()
+            )
+        }
+
+        verify(exactly = 1) { repositoryMock.update(oppdatertKrav) }
+    }
+
+    @Test
+    fun `Ved feil i oppgave skal joarkref lagres, og det skal det kastes exception oppover`() {
+        coEvery { oppgaveMock.opprettOppgave(any(), any()) } throws IOException()
+
+        assertThrows<IOException> { prosessor.prosesser(jobb) }
+
+        assertThat(oppdatertKrav.journalpostId).isEqualTo(arkivReferanse)
+        assertThat(oppdatertKrav.oppgaveId).isNull()
+
+        coVerify(exactly = 1) { joarkMock.opprettOgFerdigstillJournalpost(any(), any(), any(), any(), any(), any(), any()) }
+        coVerify(exactly = 1) { oppgaveMock.opprettOppgave(any(), any()) }
+        verify(exactly = 1) { repositoryMock.update(oppdatertKrav) }
+    }
+}

--- a/src/test/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/GravidKravEndreProcessorTest.kt
+++ b/src/test/kotlin/no/nav/helse/fritakagp/processing/gravid/krav/GravidKravEndreProcessorTest.kt
@@ -60,7 +60,7 @@ class GravidKravEndreProcessorTest {
     }
 
     @Test
-    fun `skal journalføre, opprette oppgave og oppdatere søknaden i databasen`() {
+    fun `skal journalføre, opprette oppgave og oppdatere kravet i databasen`() {
         prosessor.prosesser(jobb)
 
         assertThat(oppdatertKrav.journalpostId).isEqualTo(arkivReferanse)


### PR DESCRIPTION
Reduser antall jobber som opprettes dersom noen endrer et krav: 
Ikke lage jobb for slett, ikke lag robot-jobb for ny, lag heller en manuell “endreoppgave” til saksbehandler med info om orginale og oppdaterte verdier.
 