### PR TITLE
fjernet dokumentasjon fra krav-modellene i backend 

### DIFF
--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/GravidRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/GravidRoutes.kt
@@ -137,7 +137,6 @@ fun Route.gravidRoutes(
 
                 val krav = request.toDomain(innloggetFnr, sendtAvNavn, navn)
                 belopBeregning.beregnBeløpGravid(krav)
-                processDocumentForGCPStorage(request.dokumentasjon, virusScanner, bucket, krav.id)
 
                 gravidKravRepo.insert(krav)
                 bakgunnsjobbService.opprettJobb<GravidKravProcessor>(

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/KroniskRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/KroniskRoutes.kt
@@ -164,9 +164,6 @@ fun Route.kroniskRoutes(
                 logger.info("KKPo: Hent grunnbeløp.")
                 belopBeregning.beregnBeløpKronisk(krav)
 
-                logger.info("KKPo: Prosesser dokument for GCP-lagring.")
-                processDocumentForGCPStorage(request.dokumentasjon, virusScanner, bucket, krav.id)
-
                 logger.info("KKPo: Legg til krav i db.")
                 kroniskKravRepo.insert(krav)
                 bakgunnsjobbService.opprettJobb<KroniskKravProcessor>(

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/resreq/GravidResReq.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/resreq/GravidResReq.kt
@@ -11,7 +11,7 @@ import no.nav.helse.fritakagp.domain.OmplasseringAarsak
 import no.nav.helse.fritakagp.domain.Tiltak
 import no.nav.helse.fritakagp.web.api.resreq.validation.datoerHarRiktigRekkefolge
 import no.nav.helse.fritakagp.web.api.resreq.validation.isAvStorrelse
-import no.nav.helse.fritakagp.web.api.resreq.validation.isGodskjentFiletyper
+import no.nav.helse.fritakagp.web.api.resreq.validation.isGodkjentFiltype
 import no.nav.helse.fritakagp.web.api.resreq.validation.isVirksomhet
 import no.nav.helse.fritakagp.web.api.resreq.validation.maanedsInntektErMellomNullOgTiMil
 import no.nav.helse.fritakagp.web.api.resreq.validation.måHaAktivtArbeidsforhold
@@ -63,7 +63,7 @@ data class GravidSoknadRequest(
             }
 
             if (!this@GravidSoknadRequest.dokumentasjon.isNullOrEmpty()) {
-                validate(GravidSoknadRequest::dokumentasjon).isGodskjentFiletyper()
+                validate(GravidSoknadRequest::dokumentasjon).isGodkjentFiltype()
                 validate(GravidSoknadRequest::dokumentasjon).isAvStorrelse(SMALLEST_PDF_SIZE, 10L * MB)
             }
         }
@@ -91,8 +91,7 @@ data class GravidKravRequest(
     val perioder: List<Arbeidsgiverperiode>,
     val bekreftet: Boolean,
     val kontrollDager: Int?,
-    val antallDager: Int,
-    val dokumentasjon: String? // TODO: kan slettes(?)
+    val antallDager: Int
 ) {
     fun validate(aktuelleArbeidsforhold: List<Arbeidsforhold>) {
         validate(this) {
@@ -110,11 +109,6 @@ data class GravidKravRequest(
                 validate(Arbeidsgiverperiode::gradering).isLessThanOrEqualTo(1.0)
                 validate(Arbeidsgiverperiode::gradering).isGreaterThanOrEqualTo(0.2)
             }
-
-            if (!this@GravidKravRequest.dokumentasjon.isNullOrEmpty()) {
-                validate(GravidKravRequest::dokumentasjon).isGodskjentFiletyper()
-                validate(GravidKravRequest::dokumentasjon).isAvStorrelse(SMALLEST_PDF_SIZE, (10L * MB))
-            }
         }
     }
 
@@ -125,7 +119,6 @@ data class GravidKravRequest(
         perioder = perioder,
         sendtAv = sendtAv,
         sendtAvNavn = sendtAvNavn,
-        harVedlegg = !dokumentasjon.isNullOrEmpty(),
         kontrollDager = kontrollDager,
         antallDager = antallDager
     )

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/resreq/KroniskResReq.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/resreq/KroniskResReq.kt
@@ -12,7 +12,7 @@ import no.nav.helse.fritakagp.web.api.resreq.validation.ikkeFlereFravaersdagerEn
 import no.nav.helse.fritakagp.web.api.resreq.validation.ingenDataEldreEnn
 import no.nav.helse.fritakagp.web.api.resreq.validation.ingenDataFraFremtiden
 import no.nav.helse.fritakagp.web.api.resreq.validation.isAvStorrelse
-import no.nav.helse.fritakagp.web.api.resreq.validation.isGodskjentFiletyper
+import no.nav.helse.fritakagp.web.api.resreq.validation.isGodkjentFiltype
 import no.nav.helse.fritakagp.web.api.resreq.validation.isVirksomhet
 import no.nav.helse.fritakagp.web.api.resreq.validation.maanedsInntektErMellomNullOgTiMil
 import no.nav.helse.fritakagp.web.api.resreq.validation.måHaAktivtArbeidsforhold
@@ -58,7 +58,7 @@ data class KroniskSoknadRequest(
             }
 
             if (!this@KroniskSoknadRequest.dokumentasjon.isNullOrEmpty()) {
-                validate(KroniskSoknadRequest::dokumentasjon).isGodskjentFiletyper()
+                validate(KroniskSoknadRequest::dokumentasjon).isGodkjentFiltype()
                 validate(KroniskSoknadRequest::dokumentasjon).isAvStorrelse(SMALLEST_PDF_SIZE, 10L * MB)
             }
         }
@@ -83,7 +83,6 @@ data class KroniskKravRequest(
     val identitetsnummer: String,
     val perioder: List<Arbeidsgiverperiode>,
     val bekreftet: Boolean,
-    val dokumentasjon: String?,
     val kontrollDager: Int?,
     val antallDager: Int
 ) {
@@ -102,11 +101,6 @@ data class KroniskKravRequest(
                 validate(Arbeidsgiverperiode::gradering).isLessThanOrEqualTo(1.0)
                 validate(Arbeidsgiverperiode::gradering).isGreaterThanOrEqualTo(0.2)
             }
-
-            if (!this@KroniskKravRequest.dokumentasjon.isNullOrEmpty()) {
-                validate(KroniskKravRequest::dokumentasjon).isGodskjentFiletyper()
-                validate(KroniskKravRequest::dokumentasjon).isAvStorrelse(SMALLEST_PDF_SIZE, 10L * MB)
-            }
         }
     }
 
@@ -117,7 +111,6 @@ data class KroniskKravRequest(
         perioder = perioder,
         sendtAv = sendtAv,
         sendtAvNavn = sendtAvNavn,
-        harVedlegg = !dokumentasjon.isNullOrEmpty(),
         kontrollDager = kontrollDager,
         antallDager = antallDager
     )

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/resreq/validation/CustomValidatorConstraints.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/resreq/validation/CustomValidatorConstraints.kt
@@ -34,7 +34,7 @@ fun <E> Validator<E>.Property<Double?>.maanedsInntektErMellomNullOgTiMil() =
     }
 
 class DataUrlExtensionConstraints : CustomConstraint
-fun <E> Validator<E>.Property<String?>.isGodskjentFiletyper() =
+fun <E> Validator<E>.Property<String?>.isGodkjentFiltype() =
     this.validate(DataUrlExtensionConstraints()) {
         return@validate enumContains<GodkjenteFiletyper>(extractFilExtDel(it!!.uppercase()))
     }

--- a/src/test/kotlin/no/nav/helse/GravidTestData.kt
+++ b/src/test/kotlin/no/nav/helse/GravidTestData.kt
@@ -127,7 +127,6 @@ aąbcćdeęfghijlłmnńoóprsśtuwź
         ),
 
         bekreftet = true,
-        dokumentasjon = null,
         kontrollDager = null,
         antallDager = 4
     )
@@ -146,7 +145,6 @@ aąbcćdeęfghijlłmnńoóprsśtuwź
         ),
 
         bekreftet = true,
-        dokumentasjon = null,
         kontrollDager = null,
         antallDager = 260
     )
@@ -177,15 +175,8 @@ aąbcćdeęfghijlłmnńoóprsśtuwź
         ),
 
         bekreftet = true,
-        dokumentasjon = null,
         kontrollDager = null,
         antallDager = 4
-    )
-
-    val gravidKravRequestMedFil = gravidKravRequestValid.copy(
-        dokumentasjon = """
-                data:image/pdf;base64,TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gQWxpcXVhbSB2aXRhZSBlcm9zIGEgZmVsaXMgbGFjaW5pYSBzb2xsaWNpdHVkaW4gdXQgZWdldCB0b3J0b3IuIFBoYXNlbGx1cyB2ZWhpY3VsYSBlZ2VzdGFzIG1hdHRpcy4gTnVuYyBldSBsaWJlcm8gdWxsYW1jb3JwZXIsIHBsYWNlcmF0IHNhcGllbiBlZ2V0LCBhY2N1bXNhbiBwdXJ1cy4gTWFlY2VuYXMgbWF4aW11cywgcHVydXMgbmVjIGxhY2luaWEgcHVsdmluYXIsIGR1aSBlbmltIGlhY3VsaXMgZGlhbSwgcXVpcyB2aXZlcnJhIG1hc3NhIGxpZ3VsYSBzaXQgYW1ldCBudWxsYS4gU2VkIG1heGltdXMgZXVpc21vZCBhbnRlIGluIHBvc3VlcmUuIFN1c3BlbmRpc3NlIGxpZ3VsYSB0ZWxsdXMsIGZpbmlidXMgdmVsIHBsYWNlcmF0IGlkLCBtYXhpbXVzIHNlZCBhbnRlLiBGdXNjZSBzaXQgYW1ldCBmZXJtZW50dW0gbWFnbmEuCgpDbGFzcyBhcHRlbnQgdGFjaXRpIHNvY2lvc3F1IGFkIGxpdG9yYSB0b3JxdWVudCBwZXIgY29udWJpYSBub3N0cmEsIHBlciBpbmNlcHRvcyBoaW1lbmFlb3MuIERvbmVjIGV1IHRvcnRvciBtYWxlc3VhZGEsIHVsbGFtY29ycGVyIG5pc2wgYXQsIHZ1bHB1dGF0ZSBlc3QuIFZpdmFtdXMgaWQgbG9yZW0gZWdlc3RhcyBhcmN1IHNvZGFsZXMgc2VtcGVyIHZpdGFlIHZlc3RpYnVsdW0gZG9sb3IuIENyYXMgZGFwaWJ1cywgZXJhdCBuZWMgZmF1Y2lidXMgZGFwaWJ1cywgZHVpIHZlbGl0IG9ybmFyZSB0ZWxsdXMsIHF1aXMgdWx0cmljaWVzIGxlbyB0ZWxsdXMgdXQgZXJhdC4gTWFlY2VuYXMgcG9ydGEgdGluY2lkdW50IHBsYWNlcmF0LiBDcmFzIGRpZ25pc3NpbSBsZWN0dXMgdGVsbHVzLCBldCBpbnRlcmR1bSByaXN1cyBwZWxsZW50ZXNxdWUgYXVjdG9yLiBJbiBtYXhpbXVzIGxhY2luaWEgbGVjdHVzLCBhIHNvZGFsZXMgbnVsbGEgdmFyaXVzIGdyYXZpZGEuIEV0aWFtIGhlbmRyZXJpdCBhdWd1ZSBvZGlvLCB2ZWwgcGhhcmV0cmEgb3JjaSBtYWxlc3VhZGEgbmVjLiBQZWxsZW50ZXNxdWUgaGFiaXRhbnQgbW9yYmkgdHJpc3RpcXVlIHNlbmVjdHVzIGV0IG5ldHVzIGV0IG1hbGVzdWFkYSBmYW1lcyBhYyB0dXJwaXMgZWdlc3Rhcy4gU2VkIGV0IGNvbmRpbWVudHVtIG9yY2ksIHZlbCBtYWxlc3VhZGEgbmVxdWUu
-        """.trimIndent()
     )
 
     // Innrapportert feil POH-693 Gravid Krav - Backendvalidereing feiler når man sender inn krav for bare en dag.
@@ -202,7 +193,6 @@ aąbcćdeęfghijlłmnńoóprsśtuwź
         ),
 
         bekreftet = true,
-        dokumentasjon = null,
         kontrollDager = null,
         antallDager = 4
     )

--- a/src/test/kotlin/no/nav/helse/KroniskTestData.kt
+++ b/src/test/kotlin/no/nav/helse/KroniskTestData.kt
@@ -15,7 +15,6 @@ import java.time.format.DateTimeFormatter
 import kotlin.random.Random
 
 object KroniskTestData {
-    val validNavn = "Personliga Person"
     val validIdentitetsnummer = "20015001543"
     val validOrgNr = "917404437"
     val validSendtAvNavn = "Ola M Avsender"
@@ -60,7 +59,6 @@ object KroniskTestData {
             )
         ),
         bekreftet = true,
-        dokumentasjon = null,
         kontrollDager = null,
         antallDager = 4
     )
@@ -91,15 +89,8 @@ object KroniskTestData {
         ),
 
         bekreftet = true,
-        dokumentasjon = null,
         kontrollDager = null,
         antallDager = 4
-    )
-
-    val kroniskKravRequestMedFil = kroniskKravRequestValid.copy(
-        dokumentasjon = """
-                data:image/pdf;base64,TG9yZW0gaXBzdW0gZG9sb3Igc2l0IGFtZXQsIGNvbnNlY3RldHVyIGFkaXBpc2NpbmcgZWxpdC4gQWxpcXVhbSB2aXRhZSBlcm9zIGEgZmVsaXMgbGFjaW5pYSBzb2xsaWNpdHVkaW4gdXQgZWdldCB0b3J0b3IuIFBoYXNlbGx1cyB2ZWhpY3VsYSBlZ2VzdGFzIG1hdHRpcy4gTnVuYyBldSBsaWJlcm8gdWxsYW1jb3JwZXIsIHBsYWNlcmF0IHNhcGllbiBlZ2V0LCBhY2N1bXNhbiBwdXJ1cy4gTWFlY2VuYXMgbWF4aW11cywgcHVydXMgbmVjIGxhY2luaWEgcHVsdmluYXIsIGR1aSBlbmltIGlhY3VsaXMgZGlhbSwgcXVpcyB2aXZlcnJhIG1hc3NhIGxpZ3VsYSBzaXQgYW1ldCBudWxsYS4gU2VkIG1heGltdXMgZXVpc21vZCBhbnRlIGluIHBvc3VlcmUuIFN1c3BlbmRpc3NlIGxpZ3VsYSB0ZWxsdXMsIGZpbmlidXMgdmVsIHBsYWNlcmF0IGlkLCBtYXhpbXVzIHNlZCBhbnRlLiBGdXNjZSBzaXQgYW1ldCBmZXJtZW50dW0gbWFnbmEuCgpDbGFzcyBhcHRlbnQgdGFjaXRpIHNvY2lvc3F1IGFkIGxpdG9yYSB0b3JxdWVudCBwZXIgY29udWJpYSBub3N0cmEsIHBlciBpbmNlcHRvcyBoaW1lbmFlb3MuIERvbmVjIGV1IHRvcnRvciBtYWxlc3VhZGEsIHVsbGFtY29ycGVyIG5pc2wgYXQsIHZ1bHB1dGF0ZSBlc3QuIFZpdmFtdXMgaWQgbG9yZW0gZWdlc3RhcyBhcmN1IHNvZGFsZXMgc2VtcGVyIHZpdGFlIHZlc3RpYnVsdW0gZG9sb3IuIENyYXMgZGFwaWJ1cywgZXJhdCBuZWMgZmF1Y2lidXMgZGFwaWJ1cywgZHVpIHZlbGl0IG9ybmFyZSB0ZWxsdXMsIHF1aXMgdWx0cmljaWVzIGxlbyB0ZWxsdXMgdXQgZXJhdC4gTWFlY2VuYXMgcG9ydGEgdGluY2lkdW50IHBsYWNlcmF0LiBDcmFzIGRpZ25pc3NpbSBsZWN0dXMgdGVsbHVzLCBldCBpbnRlcmR1bSByaXN1cyBwZWxsZW50ZXNxdWUgYXVjdG9yLiBJbiBtYXhpbXVzIGxhY2luaWEgbGVjdHVzLCBhIHNvZGFsZXMgbnVsbGEgdmFyaXVzIGdyYXZpZGEuIEV0aWFtIGhlbmRyZXJpdCBhdWd1ZSBvZGlvLCB2ZWwgcGhhcmV0cmEgb3JjaSBtYWxlc3VhZGEgbmVjLiBQZWxsZW50ZXNxdWUgaGFiaXRhbnQgbW9yYmkgdHJpc3RpcXVlIHNlbmVjdHVzIGV0IG5ldHVzIGV0IG1hbGVzdWFkYSBmYW1lcyBhYyB0dXJwaXMgZWdlc3Rhcy4gU2VkIGV0IGNvbmRpbWVudHVtIG9yY2ksIHZlbCBtYWxlc3VhZGEgbmVxdWUu
-        """.trimIndent()
     )
 
     val kroniskKrav = KroniskKrav(

--- a/src/test/kotlin/no/nav/helse/fritakagp/web/api/resreq/GravidKravRequestTest.kt
+++ b/src/test/kotlin/no/nav/helse/fritakagp/web/api/resreq/GravidKravRequestTest.kt
@@ -76,8 +76,7 @@ class GravidKravRequestTest {
     }
 
     @Test
-    internal fun `mapping til domenemodell tar med harVedleggflagg`() {
-        assertThat(GravidTestData.gravidKravRequestMedFil.toDomain(sendtAv, sendtAvNavn, navn).harVedlegg).isTrue
+    internal fun `mapping til domenemodell setter harVedlegg til false - støtte for vedlegg er fjernet fra krav`() {
         assertThat(GravidTestData.gravidKravRequestValid.toDomain(sendtAv, sendtAvNavn, navn).harVedlegg).isFalse
     }
 

--- a/src/test/kotlin/no/nav/helse/fritakagp/web/api/resreq/KroniskKravRequestTest.kt
+++ b/src/test/kotlin/no/nav/helse/fritakagp/web/api/resreq/KroniskKravRequestTest.kt
@@ -57,8 +57,7 @@ class KroniskKravRequestTest {
     }
 
     @Test
-    internal fun `mapping til domenemodell tar med harVedleggflagg`() {
-        Assertions.assertThat(KroniskTestData.kroniskKravRequestMedFil.toDomain(sendtAv, sendtAvNavn, navn).harVedlegg).isTrue
+    internal fun `mapping til domenemodell setter harVedlegg til default false - dokumentasjon er fjernet fra krav`() {
         Assertions.assertThat(KroniskTestData.kroniskKravRequestValid.toDomain(sendtAv, sendtAvNavn, navn).harVedlegg).isFalse
     }
 

--- a/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/GravidKravHTTPTests.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/GravidKravHTTPTests.kt
@@ -126,18 +126,6 @@ class GravidKravHTTPTests : SystemTestBase() {
     }
 
     @Test
-    fun `Skal returnere Created og lagre flagg når fil er vedlagt`() = suspendableTest {
-        val response = httpClient.post {
-            appUrl(kravGravidUrl)
-            contentType(ContentType.Application.Json)
-            loggedInAs("123456789")
-            setBody(GravidTestData.gravidKravRequestMedFil)
-        }
-
-        assertThat(response.status).isEqualTo(HttpStatusCode.Created)
-    }
-
-    @Test
     fun `Skal returnere en valideringfeil`() = suspendableTest {
         val response =
             httpClient.post {

--- a/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/KroniskKravHTTPTests.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/KroniskKravHTTPTests.kt
@@ -92,20 +92,6 @@ class KroniskKravHTTPTests : SystemTestBase() {
     }
 
     @Test
-    fun `Skal returnere Created når fil er vedlagt`() = suspendableTest {
-        val response = httpClient.post {
-            appUrl(kravKroniskUrl)
-            contentType(ContentType.Application.Json)
-            loggedInAs("123456789")
-            setBody(KroniskTestData.kroniskKravRequestMedFil)
-        }
-
-        val krav = response.body<KroniskKrav>()
-        assertThat(response.status).isEqualTo(HttpStatusCode.Created)
-        assertThat(krav.harVedlegg).isEqualTo(true)
-    }
-
-    @Test
     fun `Skal returnere full propertypath for periode`() = suspendableTest {
         val response =
             httpClient.post {


### PR DESCRIPTION
dette er fjerne fra frontend for lenge siden, og det skal kun være mulig å legge ved / laste opp filer i søknad, ikke krav.

Testet ok i dev