### PR TITLE
Fas ut bruken av vår egen proxy for å snakke med pdl

### DIFF
--- a/deploy/dev.yml
+++ b/deploy/dev.yml
@@ -10,6 +10,7 @@ accessOutbound:
     - kafka-schema-registry.nais-q.adeo.no
     - dokarkiv.dev-fss-pub.nais.io
     - helsearbeidsgiver-proxy.dev-fss-pub.nais.io
+    - pdl-api.dev-fss-pub.nais.io
     - oppgave-q1.dev-fss-pub.nais.io
     - api-gw-q1.oera.no
     - tt02.altinn.no
@@ -36,7 +37,6 @@ env:
     value: api://dev-fss.teamdokumenthandtering.dokarkiv-q1/.default
   - name: OPPGAVE_SCOPE
     value: api://dev-fss.oppgavehandtering.oppgave-q1/.default
-    # TODO ikke i prod
   - name: PDL_SCOPE
     value: api://dev-fss.pdl.pdl-api/.default
   - name: PROXY_SCOPE
@@ -54,7 +54,7 @@ env:
   - name: OPPGAVEBEHANDLING_URL
     value: https://oppgave-q1.dev-fss-pub.nais.io/api/v1/oppgaver
   - name: PDL_URL
-    value: https://helsearbeidsgiver-proxy.dev-fss-pub.nais.io/pdl
+    value: https://pdl-api.dev-fss-pub.nais.io/graphql
   - name: ALTINN_SERVICE_OWNER_GW_URL
     value: https://api-gw-q1.oera.no/ekstern/altinn/api/serviceowner
   - name: ALTINN_ENDPOINT

--- a/deploy/prod.yml
+++ b/deploy/prod.yml
@@ -8,6 +8,7 @@ accessOutbound:
     - kafka-schema-registry.nais.adeo.no
     - dokarkiv.prod-fss-pub.nais.io
     - helsearbeidsgiver-proxy.prod-fss-pub.nais.io
+    - pdl-api.prod-fss-pub.nais.io
     - oppgave.prod-fss-pub.nais.io
     - ag-notifikasjon-produsent-api.intern.nav.no
     - api-gw.oera.no
@@ -37,6 +38,8 @@ env:
     value: api://prod-fss.oppgavehandtering.oppgave/.default
   - name: PROXY_SCOPE
     value: api://prod-fss.helsearbeidsgiver.helsearbeidsgiver-proxy/.default
+  - name: PDL_SCOPE
+    value: api://prod-fss.pdl.pdl-api/.default
   - name: FRONTEND_URL
     value: https://arbeidsgiver.nav.no/fritak-agp
     # TODO ikke i dev
@@ -53,7 +56,7 @@ env:
   - name: OPPGAVEBEHANDLING_URL
     value: https://oppgave.prod-fss-pub.nais.io/api/v1/oppgaver
   - name: PDL_URL
-    value: https://helsearbeidsgiver-proxy.prod-fss-pub.nais.io/pdl
+    value: https://pdl-api.prod-fss-pub.nais.io/graphql
   - name: ALTINN_SERVICE_OWNER_GW_URL
     value: https://api-gw.oera.no/ekstern/altinn/api/serviceowner
   - name: ALTINN_ENDPOINT

--- a/src/main/kotlin/no/nav/helse/fritakagp/Env.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/Env.kt
@@ -91,6 +91,7 @@ class EnvOauth2(mainConfig: ApplicationConfig) {
     val scopeOppgave = "oppgavescope".prop()
     val scopeDokarkiv = "dokarkivscope".prop()
     val scopeArbeidsgivernotifikasjon = "arbeidsgivernotifikasjonscope".prop()
+    val scopePdl = "pdlscope".prop()
 
     private fun String.prop(): String =
         oauth2Config.prop(this)

--- a/src/main/kotlin/no/nav/helse/fritakagp/koin/ExternalSystemsModule.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/koin/ExternalSystemsModule.kt
@@ -119,10 +119,24 @@ fun Module.externalSystemClients(env: Env, envOauth2: EnvOauth2) {
         OAuth2TokenProvider(accessTokenService, azureAdConfig)
     } bind AccessTokenProvider::class
 
+    single(named("PDL")) {
+        val azureAdConfig = envOauth2.azureAdConfig(envOauth2.scopePdl)
+        val tokenResolver = TokenResolver()
+        val oauthHttpClient = DefaultOAuth2HttpClient(get())
+        val accessTokenService = OAuth2AccessTokenService(
+            tokenResolver,
+            OnBehalfOfTokenClient(oauthHttpClient),
+            ClientCredentialsTokenClient(oauthHttpClient),
+            TokenExchangeClient(oauthHttpClient)
+        )
+
+        OAuth2TokenProvider(accessTokenService, azureAdConfig)
+    } bind AccessTokenProvider::class
+
     single { AaregArbeidsforholdClientImpl(env.aaregUrl, get(qualifier = named("PROXY")), get()) } bind AaregArbeidsforholdClient::class
 
     single {
-        val tokenProvider: AccessTokenProvider = get(qualifier = named("PROXY"))
+        val tokenProvider: AccessTokenProvider = get(qualifier = named("PDL"))
         PdlClient(env.pdlUrl, Behandlingsgrunnlag.FRITAKAGP, tokenProvider::getToken)
     } bind PdlClient::class
 


### PR DESCRIPTION
Etter denne (https://github.com/navikt/pdl/commit/b0d860a10b88bbfea7c66fa29d1a8775e647a051) endringen i PDL, så skal vi nå kunne slutte å bruke vår egen proxy for å kommunisere med PDL i prod.