### PR TITLE
Legg til eksterne varsler og bump varslingsbiblioteket til nyeste versjon

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -50,4 +50,4 @@ slf4jVersion=2.0.9
 tokenSupportVersion=3.1.5
 utilsVersion=0.9.0
 valiktorVersion=0.12.0
-tmsVarselKotlinBuilderVersion=1.0.4
+tmsVarselKotlinBuilderVersion=2.1.1

--- a/src/main/kotlin/no/nav/helse/fritakagp/processing/brukernotifikasjon/BrukernotifikasjonService.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/processing/brukernotifikasjon/BrukernotifikasjonService.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.hag.utils.bakgrunnsjobb.Bakgrunnsjobb
 import no.nav.helsearbeidsgiver.utils.log.logger
+import no.nav.tms.varsel.action.EksternKanal
 import no.nav.tms.varsel.action.Sensitivitet
 import no.nav.tms.varsel.action.Tekst
 import no.nav.tms.varsel.action.Varseltype
@@ -31,6 +32,9 @@ class BrukernotifikasjonService(
             )
             link = frontendAppBaseUrl + jobbData.hentLenke()
             aktivFremTil = ZonedDateTime.now().plusDays(31)
+            eksternVarsling {
+                preferertKanal = EksternKanal.SMS
+            }
         }
     }
 }


### PR DESCRIPTION
**Bakgrunn**
Det ser ut som eksterne varsler glapp i overgangen fra gammelt til nytt topic for varslinger i [`BrukernotifikasjonProcessor.kt`](https://github.com/navikt/fritakagp/pull/317/files#diff-96aa94f19bee2526d9f17f299492a39c63ad60bb7416f290331f7ddce1851bc8) i https://github.com/navikt/fritakagp/pull/317.

Link til varslingsdokumentasjon her: https://navikt.github.io/tms-dokumentasjon/varsler/produsere/#oppretting-av-varsel

**Løsning**
Oppdater varslingsbiblioteket og legg til eksterne varsler med sms som foretrukket kanal. Disse vil da få en standardtekst, slik som tidligere.