### PR TITLE
Fiks locale i Docker-container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcr.io/distroless/java21
 COPY build/libs/*.jar ./
 ENV JAVA_OPTS='-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp'
-ENV LANG='nb_NO.UTF-8' LANGUAGE='nb_NO:nb' LC_ALL='nb:NO.UTF-8' TZ="Europe/Oslo"
+ENV LANG='nb_NO.UTF-8' LANGUAGE='nb_NO:nb' LC_ALL='nb_NO.UTF-8' TZ="Europe/Oslo"
 ENTRYPOINT ["java", "-jar", "/app.jar"]
 EXPOSE 8080


### PR DESCRIPTION
Jeg prøvde dette i et forsøk på å fikse et problem med en URL som inneholdt Ø. Det løste ikke problemet, men jeg tror fremdeles det er en korrekt endring.