### PR TITLE
Fiks henting av og utregning med grunnbeløp

### DIFF
--- a/deploy/dev.yml
+++ b/deploy/dev.yml
@@ -57,7 +57,7 @@ env:
   - name: DOKARKIV_URL
     value: https://dokarkiv.dev-fss-pub.nais.io/rest/journalpostapi/v1
   - name: GRUNNBELOEP_URL
-    value: https://g.nav.no/api/v1/grunnbeløp
+    value: https://g.nav.no/api/v1/grunnbeloep
   - name: OPPGAVEBEHANDLING_URL
     value: https://oppgave-q1.dev-fss-pub.nais.io/api/v1/oppgaver
   - name: PDL_URL

--- a/deploy/prod.yml
+++ b/deploy/prod.yml
@@ -57,7 +57,7 @@ env:
   - name: DOKARKIV_URL
     value: https://dokarkiv.prod-fss-pub.nais.io/rest/journalpostapi/v1
   - name: GRUNNBELOEP_URL
-    value: https://g.nav.no/api/v1/grunnbeløp
+    value: https://g.nav.no/api/v1/grunnbeloep
   - name: OPPGAVEBEHANDLING_URL
     value: https://oppgave.prod-fss-pub.nais.io/api/v1/oppgaver
   - name: PDL_URL

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/BeloepBeregning.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/BeloepBeregning.kt
@@ -7,22 +7,26 @@ import java.math.RoundingMode
 class BeloepBeregning(
     private val grunnbeloepClient: GrunnbeloepClient
 ) {
-    fun beregnBeløpKronisk(krav: KroniskKrav) = beregnPeriodeData(krav.perioder, krav.antallDager)
+    fun beregnBeloepKronisk(krav: KroniskKrav) = beregnPeriodeData(krav.perioder, krav.antallDager)
 
-    fun beregnBeløpGravid(krav: GravidKrav) = beregnPeriodeData(krav.perioder, krav.antallDager)
+    fun beregnBeloepGravid(krav: GravidKrav) = beregnPeriodeData(krav.perioder, krav.antallDager)
 
     private fun beregnPeriodeData(perioder: List<Arbeidsgiverperiode>, antallDager: Int) {
-        perioder.forEach {
-            val seksG = grunnbeloepClient.hentGrunnbeløp(it.fom).grunnbeløp * 6.0
-            val arslonn = it.månedsinntekt * 12
-            it.dagsats = if (arslonn < seksG) {
-                round2DigitDecimal(arslonn / antallDager)
-            } else {
-                round2DigitDecimal(seksG / antallDager)
-            }
-            it.belop = round2DigitDecimal(it.dagsats * it.antallDagerMedRefusjon * it.gradering)
+        perioder.forEach { periode ->
+            val grunnbeloep = grunnbeloepClient.hentGrunnbeloep(periode.fom)
+            val seksG = BigDecimal(grunnbeloep).multiply(BigDecimal(6))
+            val aarsloenn = BigDecimal(periode.månedsinntekt).multiply(BigDecimal(12))
+
+            periode.dagsats = aarsloenn.min(seksG)
+                .divide(BigDecimal(antallDager), 2, RoundingMode.HALF_UP)
+                .toDouble()
+
+            periode.belop =
+                BigDecimal(periode.dagsats)
+                    .multiply(BigDecimal(periode.antallDagerMedRefusjon))
+                    .multiply(BigDecimal(periode.gradering))
+                    .setScale(2, RoundingMode.HALF_UP)
+                    .toDouble()
         }
     }
-
-    private fun round2DigitDecimal(value: Double): Double = BigDecimal(value).setScale(2, RoundingMode.HALF_UP).toDouble()
 }

--- a/src/main/kotlin/no/nav/helse/fritakagp/integration/GrunnbeloepClient.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/integration/GrunnbeloepClient.kt
@@ -12,31 +12,19 @@ class GrunnbeloepClient(
     private val url: String,
     private val httpClient: HttpClient
 ) {
-    private val cache = LocalCache<GrunnbeløpInfo>(LocalCache.Config(1.days, 5))
+    private val cache = LocalCache<GrunnbeloepResponse>(LocalCache.Config(1.days, 5))
 
-    fun hentGrunnbeløp(dato: LocalDate): GrunnbeløpInfo {
+    fun hentGrunnbeloep(dato: LocalDate): Int {
         val cacheKey = if (dato.month.value >= 5) "${dato.year}-05" else "${dato.year - 1}-05"
         return runBlocking {
             cache.getOrPut(cacheKey) {
                 httpClient.get("$url?dato=$dato").body()
             }
         }
+            .grunnbeloep
     }
 }
 
-/**
- * {
-"dato": "2020-05-01",
-"grunnbeløp": 101351,
-"grunnbeløpPerMåned": 8446,
-"gjennomsnittPerÅr": 100853,
-"omregningsfaktor": 1.014951
-}
- */
-data class GrunnbeløpInfo(
-    val dato: LocalDate,
-    val grunnbeløp: Int,
-    val grunnbeløpPerMåned: Int,
-    val gjennomsnittPerÅr: Int,
-    val omregningsfaktor: Double
+private data class GrunnbeloepResponse(
+    val grunnbeloep: Int
 )

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/GravidRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/GravidRoutes.kt
@@ -2,8 +2,6 @@ package no.nav.helse.fritakagp.web.api
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.application.application
-import io.ktor.server.application.call
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -143,7 +141,7 @@ fun Route.gravidRoutes(
                 val navn = pdlService.hentNavn(request.identitetsnummer)
 
                 val krav = request.toDomain(innloggetFnr, sendtAvNavn, navn)
-                belopBeregning.beregnBeløpGravid(krav)
+                belopBeregning.beregnBeloepGravid(krav)
 
                 gravidKravRepo.insert(krav)
                 bakgunnsjobbService.opprettJobb<GravidKravProcessor>(
@@ -187,7 +185,7 @@ fun Route.gravidRoutes(
                 }
 
                 val kravTilOppdatering = request.toDomain(innloggetFnr, sendtAvNavn, navn)
-                belopBeregning.beregnBeløpGravid(kravTilOppdatering)
+                belopBeregning.beregnBeloepGravid(kravTilOppdatering)
 
                 if (forrigeKrav.isDuplicate(kravTilOppdatering)) {
                     return@patch call.respond(HttpStatusCode.Conflict)

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/KroniskRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/KroniskRoutes.kt
@@ -2,8 +2,6 @@ package no.nav.helse.fritakagp.web.api
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.application.application
-import io.ktor.server.application.call
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -169,7 +167,7 @@ fun Route.kroniskRoutes(
                 val krav = request.toDomain(innloggetFnr, sendtAvNavn, navn)
 
                 logger.info("KKPo: Hent grunnbeløp.")
-                belopBeregning.beregnBeløpKronisk(krav)
+                belopBeregning.beregnBeloepKronisk(krav)
 
                 logger.info("KKPo: Legg til krav i db.")
                 kroniskKravRepo.insert(krav)
@@ -219,7 +217,7 @@ fun Route.kroniskRoutes(
                 }
 
                 val kravTilOppdatering = request.toDomain(innloggetFnr, sendtAvNavn, navn)
-                belopBeregning.beregnBeløpKronisk(kravTilOppdatering)
+                belopBeregning.beregnBeloepKronisk(kravTilOppdatering)
                 if (forrigeKrav.isDuplicate(kravTilOppdatering)) {
                     return@patch call.respond(HttpStatusCode.Conflict)
                 }

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -135,7 +135,7 @@ brreg_enhet_url: ${?ENHETSREGISTERET}
 aareg_url: "https://aareg-services.dev-fss-pub.nais.io/api/v1/arbeidstaker/arbeidsforhold?sporingsinformasjon=false&historikk=false"
 aareg_url: ${?AAREG_URL}
 
-grunnbeloep_url: "https://g.nav.no/api/v1/grunnbeløp"
+grunnbeloep_url: "https://g.nav.no/api/v1/grunnbeloep"
 grunnbeloep_url: ${?GRUNNBELOEP_URL}
 
 arbeidsgiver_notifikasjon_api_url: "https://notifikasjon-fake-produsent-api.labs.nais.io/api/graphql"

--- a/src/test/kotlin/no/nav/helse/fritakagp/web/api/resreq/GravidKravRequestTest.kt
+++ b/src/test/kotlin/no/nav/helse/fritakagp/web/api/resreq/GravidKravRequestTest.kt
@@ -106,12 +106,12 @@ class GravidKravRequestTest {
 
     @Test
     fun `Beløp og dagsats er beregnet`() {
-        val grunnbeloepClient = mockk<GrunnbeloepClient>(relaxed = true)
-        every { grunnbeloepClient.hentGrunnbeløp(any()).grunnbeløp } returns 106399
+        val grunnbeloepClient = mockk<GrunnbeloepClient>()
+        every { grunnbeloepClient.hentGrunnbeloep(any()) } returns 106399
 
         val belopBeregning = BeloepBeregning(grunnbeloepClient)
         val krav = GravidTestData.gravidKravRequestValid.toDomain(sendtAv, sendtAvNavn, navn)
-        belopBeregning.beregnBeløpGravid(krav)
+        belopBeregning.beregnBeloepGravid(krav)
 
         assertThat(krav.perioder.first().dagsats).isEqualTo(7772.4)
         assertThat(krav.perioder.first().belop).isEqualTo(12435.84)
@@ -119,12 +119,12 @@ class GravidKravRequestTest {
 
     @Test
     fun `Beløp har riktig desimaltall`() {
-        val grunnbeloepClient = mockk<GrunnbeloepClient>(relaxed = true)
-        every { grunnbeloepClient.hentGrunnbeløp(any()).grunnbeløp } returns 106399
+        val grunnbeloepClient = mockk<GrunnbeloepClient>()
+        every { grunnbeloepClient.hentGrunnbeloep(any()) } returns 106399
 
         val belopBeregning = BeloepBeregning(grunnbeloepClient)
         val krav = GravidTestData.gravidKravRequestWithWrongDecimal.toDomain(sendtAv, sendtAvNavn, navn)
-        belopBeregning.beregnBeløpGravid(krav)
+        belopBeregning.beregnBeloepGravid(krav)
 
         assertThat(krav.perioder.first().belop).isEqualTo(2848.6)
     }


### PR DESCRIPTION
Bytter URL-en for å hente grunnbeløp, slik at vi unngår problemet med Ø i URL-en som oppsto i oppdateringen til Java 21.

Da jeg kikket på hvor grunnbeløpet ble brukt, så oppdaget jeg en del aritmatiske operasjoner på `Double`-typen, som har kjente svakheter. Byttet disse til å bruke `BigDecimal`, som er trygt å regne med.