### PR TITLE
Bruk Aareg-klient som filtrerer ut ugyldige orgnr

### DIFF
--- a/deploy/dev.yml
+++ b/deploy/dev.yml
@@ -63,7 +63,7 @@ env:
   - name: PDL_URL
     value: https://pdl-api.dev-fss-pub.nais.io/graphql
   - name: AAREG_URL
-    value: https://aareg-services.dev-fss-pub.nais.io/api/v1/arbeidstaker/arbeidsforhold?sporingsinformasjon=false&historikk=false
+    value: https://aareg-services.dev-fss-pub.nais.io
   - name: ALTINN_SERVICE_OWNER_URL
     value: https://tt02.altinn.no/api/serviceowner
   - name: ALTINN_ENDPOINT

--- a/deploy/prod.yml
+++ b/deploy/prod.yml
@@ -51,7 +51,7 @@ env:
   - name: FRONTEND_URL
     value: https://arbeidsgiver.nav.no/fritak-agp
   - name: AAREG_URL
-    value: https://aareg-services.prod-fss-pub.nais.io/api/v1/arbeidstaker/arbeidsforhold?sporingsinformasjon=false&historikk=false
+    value: https://aareg-services.prod-fss-pub.nais.io
   - name: ARBEIDSGIVER_NOTIFIKASJON_API_URL
     value: https://ag-notifikasjon-produsent-api.intern.nav.no/api/graphql
   - name: DOKARKIV_URL

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ versionUpdatesVersion=0.42.0
 dependencyAnalysisVersion=1.10.0
 
 # Client versions
-aaregClientVersion=1.0.1
+aaregClientVersion=1.0.2
 altinnClientVersion=1.2.0
 arbeidsgiverNotifikasjonKlientVersion=3.5.0
 dokarkivKlientVersion=0.5.0

--- a/src/main/kotlin/no/nav/helse/fritakagp/koin/ExternalSystemsModule.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/koin/ExternalSystemsModule.kt
@@ -23,7 +23,6 @@ import no.nav.helsearbeidsgiver.pdl.PdlClient
 import no.nav.helsearbeidsgiver.utils.cache.LocalCache
 import org.koin.core.module.Module
 import org.koin.dsl.bind
-import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.minutes
 
 fun Module.externalSystemClients(env: Env) {
@@ -45,8 +44,8 @@ fun Module.externalSystemClients(env: Env) {
     single {
         val azureAuthClient: AuthClient = get()
         AaregClient(
-            url = env.aaregUrl,
-            cacheConfig = LocalCache.Config(7.days, 500),
+            baseUrl = env.aaregUrl,
+            cacheConfig = LocalCache.Config(5.minutes, 500),
             getAccessToken = azureAuthClient.fetchToken(IdentityProvider.AZURE_AD, env.scopeAareg)
         )
     } bind AaregClient::class

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -132,7 +132,7 @@ frontend_app_url: ${?FRONTEND_URL}
 brreg_enhet_url: "https://data.brreg.no/enhetsregisteret/api/underenheter"
 brreg_enhet_url: ${?ENHETSREGISTERET}
 
-aareg_url: "https://aareg-services.dev-fss-pub.nais.io/api/v1/arbeidstaker/arbeidsforhold?sporingsinformasjon=false&historikk=false"
+aareg_url: "https://aareg-services.dev-fss-pub.nais.io"
 aareg_url: ${?AAREG_URL}
 
 grunnbeloep_url: "https://g.nav.no/api/v1/grunnbeloep"


### PR DESCRIPTION
Skrur også ned levetiden til cachen betraktelig, basert på (denne diskusjonen)[https://github.com/navikt/helsearbeidsgiver-inntektsmelding/pull/907#discussion_r2160824343].