### PR TITLE
Øk størrelse på cache tilknyttet Altinn-klient

### DIFF
--- a/src/main/kotlin/no/nav/helse/fritakagp/koin/ExternalSystemsModule.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/koin/ExternalSystemsModule.kt
@@ -31,7 +31,7 @@ fun Module.externalSystemClients(env: Env) {
         Altinn3OBOClient(
             baseUrl = env.altinnTilgangerBaseUrl,
             serviceCode = env.altinnServiceOwnerServiceId,
-            cacheConfig = LocalCache.Config(60.minutes, 100)
+            cacheConfig = LocalCache.Config(60.minutes, 250)
         )
     } bind Altinn3OBOClient::class
 


### PR DESCRIPTION
Loggene avslører at cachen tilknyttet Altinn-klienten er for liten: https://logs.adeo.no/app/r/s/ZNOqW

Setter ny størrelse basert på hvor ofte klienten logger at den henter data: https://logs.adeo.no/app/r/s/QC2ZP