### PR TITLE
Nødvendige endringer for dokument proxy app tilgang

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,6 +78,8 @@ tasks {
         include("no/nav/helse/slowtests/**")
         outputs.upToDateWhen { false }
         group = "verification"
+        testClassesDirs = sourceSets["test"].output.classesDirs
+        classpath = sourceSets["test"].runtimeClasspath
     }
 
     jacocoTestReport {

--- a/deploy/dev.yml
+++ b/deploy/dev.yml
@@ -24,6 +24,8 @@ accessInbound:
   apps:
     - name: fritak-agp-frontend
       namespace: helsearbeidsgiver
+    - name: hag-dokument-proxy
+      namespace: helsearbeidsgiver
     - name: tokenx-token-generator
       namespace: nais
 

--- a/deploy/prod.yml
+++ b/deploy/prod.yml
@@ -23,6 +23,8 @@ accessOutbound:
     - g.nav.no
 accessInbound:
   apps:
+    - name: hag-dokument-proxy
+      namespace: helsearbeidsgiver
     - name: fritak-agp-frontend
       namespace: helsearbeidsgiver
 envFrom:

--- a/docker/local/postgres/initdb.sh
+++ b/docker/local/postgres/initdb.sh
@@ -15,7 +15,6 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
     GRANT ALL PRIVILEGES ON DATABASE fritakagp_db TO fritakagp;
 EOSQL
 
-psql -v ON_ERROR_STOP=1 --username "fritakagp" --dbname "fritakagp_db" <<-EOSQL
-
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "fritakagp_db" <<-EOSQL
+    GRANT ALL ON SCHEMA public TO fritakagp;
 EOSQL
-

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/route/GravidRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/route/GravidRoutes.kt
@@ -77,9 +77,12 @@ fun Route.gravidRoutes(
 
                 val innloggetFnr = hentFnrFraLoginToken()
                 val soeknad = gravidSoeknadRepo.getById(soeknadId)
-                if (soeknad == null || soeknad.identitetsnummer != innloggetFnr) {
+                if (soeknad == null) {
                     call.respond(HttpStatusCode.NotFound)
                 } else {
+                    if (soeknad.identitetsnummer != innloggetFnr) {
+                        authService.validerTilgangTilOrganisasjon(this, soeknad.virksomhetsnummer)
+                    }
                     soeknad.sendtAvNavn = soeknad.sendtAvNavn ?: pdlService.hentNavn(innloggetFnr)
                     soeknad.navn = soeknad.navn ?: pdlService.hentNavn(soeknad.identitetsnummer)
 

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/route/GravidRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/route/GravidRoutes.kt
@@ -80,9 +80,8 @@ fun Route.gravidRoutes(
                 if (soeknad == null) {
                     call.respond(HttpStatusCode.NotFound)
                 } else {
-                    if (soeknad.identitetsnummer != innloggetFnr) {
-                        authService.validerTilgangTilOrganisasjon(this, soeknad.virksomhetsnummer)
-                    }
+                    authService.validerTilgangTilOrganisasjon(this, soeknad.virksomhetsnummer)
+
                     soeknad.sendtAvNavn = soeknad.sendtAvNavn ?: pdlService.hentNavn(innloggetFnr)
                     soeknad.navn = soeknad.navn ?: pdlService.hentNavn(soeknad.identitetsnummer)
 

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/route/KroniskRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/route/KroniskRoutes.kt
@@ -95,10 +95,10 @@ fun Route.kroniskRoutes(
                         logger.warn("Kronisk søknad ikke funnet.")
                         call.respond(HttpStatusCode.NotFound)
                     } else {
-                        if (soeknad.identitetsnummer != innloggetFnr) {
-                            logger.info("Fnr på kronisk søknad matcher ikke innlogget fnr, sjekker om org har tilgang.")
-                            authService.validerTilgangTilOrganisasjon(this, soeknad.virksomhetsnummer)
-                        }
+
+                        logger.info("Sjekker om org har tilgang til kronisk søknad.")
+                        authService.validerTilgangTilOrganisasjon(this, soeknad.virksomhetsnummer)
+
                         logger.info("Hent personinfo fra PDL.")
                         soeknad.sendtAvNavn = soeknad.sendtAvNavn ?: pdlService.hentNavn(innloggetFnr)
                         soeknad.navn = soeknad.navn ?: pdlService.hentNavn(soeknad.identitetsnummer)

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/route/KroniskRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/route/KroniskRoutes.kt
@@ -91,10 +91,14 @@ fun Route.kroniskRoutes(
                     logger.info("Hent kronisk søknad fra database.")
                     val soeknad = kroniskSoeknadRepo.getById(soeknadId)
 
-                    if (soeknad == null || soeknad.identitetsnummer != innloggetFnr) {
-                        logger.warn("Kronisk søknad ikke funnet eller matcher ikke innlogget fnr.")
+                    if (soeknad == null) {
+                        logger.warn("Kronisk søknad ikke funnet.")
                         call.respond(HttpStatusCode.NotFound)
                     } else {
+                        if (soeknad.identitetsnummer != innloggetFnr) {
+                            logger.info("Fnr på kronisk søknad matcher ikke innlogget fnr, sjekker om org har tilgang.")
+                            authService.validerTilgangTilOrganisasjon(this, soeknad.virksomhetsnummer)
+                        }
                         logger.info("Hent personinfo fra PDL.")
                         soeknad.sendtAvNavn = soeknad.sendtAvNavn ?: pdlService.hentNavn(innloggetFnr)
                         soeknad.navn = soeknad.navn ?: pdlService.hentNavn(soeknad.identitetsnummer)

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/route/KroniskRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/route/KroniskRoutes.kt
@@ -95,7 +95,6 @@ fun Route.kroniskRoutes(
                         logger.warn("Kronisk søknad ikke funnet.")
                         call.respond(HttpStatusCode.NotFound)
                     } else {
-
                         logger.info("Sjekker om org har tilgang til kronisk søknad.")
                         authService.validerTilgangTilOrganisasjon(this, soeknad.virksomhetsnummer)
 

--- a/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/GravidSoeknadHTTPTests.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/GravidSoeknadHTTPTests.kt
@@ -18,19 +18,10 @@ class GravidSoeknadHTTPTests : SystemTestBase() {
     private val soeknadGravidUrl = "/fritak-agp-api/api/v1/gravid/soeknad"
 
     @Test
-    internal fun `Returnerer søknaden når korrekt bruker er innlogget, 404 når ikke`() = suspendableTest {
+    internal fun `Returnerer søknaden når bruker har tilgang til organisasjonen`() = suspendableTest {
         val repo by inject<GravidSoeknadRepository>()
 
         repo.insert(GravidTestData.soeknadGravid)
-
-        val response =
-            httpClient.get {
-                appUrl("$soeknadGravidUrl/${GravidTestData.soeknadGravid.id}")
-                contentType(ContentType.Application.Json)
-                loggedInAs("12345678910")
-            }
-
-        assertThat(response.status).isEqualTo(HttpStatusCode.NotFound)
 
         val accessGrantedForm = httpClient.get {
             appUrl("$soeknadGravidUrl/${GravidTestData.soeknadGravid.id}")

--- a/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/KroniskSoeknadHTTPTests.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/KroniskSoeknadHTTPTests.kt
@@ -21,18 +21,10 @@ class KroniskSoeknadHTTPTests : SystemTestBase() {
     private val soeknadKroniskUrl = "/fritak-agp-api/api/v1/kronisk/soeknad"
 
     @Test
-    internal fun `Returnerer søknaden når korrekt bruker er innlogget, 404 når ikke`() = suspendableTest {
+    internal fun `Returnerer søknaden når bruker har tilgang til organisasjonen`() = suspendableTest {
         val repo by inject<KroniskSoeknadRepository>()
 
         repo.insert(KroniskTestData.soeknadKronisk)
-        val response =
-            httpClient.get {
-                appUrl("$soeknadKroniskUrl/${KroniskTestData.soeknadKronisk.id}")
-                contentType(ContentType.Application.Json)
-                loggedInAs("12345678910")
-            }
-
-        Assertions.assertThat(response.status).isEqualTo(HttpStatusCode.NotFound)
 
         val accessGrantedForm = httpClient.get {
             appUrl("$soeknadKroniskUrl/${KroniskTestData.soeknadKronisk.id}")

--- a/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/SoeknadOrgTilgangHTTPTests.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/SoeknadOrgTilgangHTTPTests.kt
@@ -1,0 +1,47 @@
+package no.nav.helse.slowtests.systemtests.api
+
+import io.ktor.client.request.get
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import no.nav.helse.GravidTestData
+import no.nav.helse.KroniskTestData
+import no.nav.helse.fritakagp.db.GravidSoeknadRepository
+import no.nav.helse.fritakagp.db.KroniskSoeknadRepository
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.koin.test.inject
+import java.util.UUID
+
+class SoeknadOrgTilgangHTTPTests : SystemTestBase() {
+
+    @Test
+    fun `gravid soeknad - kaller validerTilgangTilOrganisasjon og returnerer 403 ved manglende tilgang`() = suspendableTest {
+        val repo by inject<GravidSoeknadRepository>()
+        val soeknad = GravidTestData.soeknadGravid.copy(id = UUID.randomUUID(), virksomhetsnummer = "999999999")
+        repo.insert(soeknad)
+
+        val response = httpClient.get {
+            appUrl("/fritak-agp-api/api/v1/gravid/soeknad/${soeknad.id}")
+            contentType(ContentType.Application.Json)
+            loggedInAs(GravidTestData.validIdentitetsnummer)
+        }
+
+        assertThat(response.status).isEqualTo(HttpStatusCode.Forbidden)
+    }
+
+    @Test
+    fun `kronisk soeknad - kaller validerTilgangTilOrganisasjon og returnerer 403 ved manglende tilgang`() = suspendableTest {
+        val repo by inject<KroniskSoeknadRepository>()
+        val soeknad = KroniskTestData.soeknadKronisk.copy(id = UUID.randomUUID(), virksomhetsnummer = "999999999")
+        repo.insert(soeknad)
+
+        val response = httpClient.get {
+            appUrl("/fritak-agp-api/api/v1/kronisk/soeknad/${soeknad.id}")
+            contentType(ContentType.Application.Json)
+            loggedInAs(KroniskTestData.validIdentitetsnummer)
+        }
+
+        assertThat(response.status).isEqualTo(HttpStatusCode.Forbidden)
+    }
+}


### PR DESCRIPTION
**Problem:**
Brukere på arbeidsflaten via dokument proxy app trenger å hente JSON data for søknad og krav
(Dette blir i proxy appen konvertert til PDF)

**Løsning:** 
Legg til proxy app til NAIS inbound access i dev og prod  
Legg til autentisering for organisasjon på søknad endepunktet (krav har dette allerede)