### PR TITLE
Legg til computed felt for pdgen

### DIFF
--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/Arbeidsgiverperiode.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/Arbeidsgiverperiode.kt
@@ -1,5 +1,6 @@
 package no.nav.helse.fritakagp.domain
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import java.time.LocalDate
 
 data class Arbeidsgiverperiode(
@@ -11,6 +12,7 @@ data class Arbeidsgiverperiode(
 ) {
     var dagsats: Double = 0.0
     var belop: Double = 0.0
+    @get:JsonProperty(access = JsonProperty.Access.READ_ONLY)
     val graderingProsent: Double
         get() = gradering * 100
 }

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/Arbeidsgiverperiode.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/Arbeidsgiverperiode.kt
@@ -12,6 +12,7 @@ data class Arbeidsgiverperiode(
 ) {
     var dagsats: Double = 0.0
     var belop: Double = 0.0
+
     @get:JsonProperty(access = JsonProperty.Access.READ_ONLY)
     val graderingProsent: Double
         get() = gradering * 100

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/Arbeidsgiverperiode.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/Arbeidsgiverperiode.kt
@@ -11,4 +11,6 @@ data class Arbeidsgiverperiode(
 ) {
     var dagsats: Double = 0.0
     var belop: Double = 0.0
+    val graderingProsent: Double
+        get() = gradering * 100
 }

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskSoeknad.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskSoeknad.kt
@@ -38,6 +38,8 @@ data class KroniskSoeknad(
     companion object {
         const val tittel = "Søknad om fritak fra arbeidsgiverperioden - kronisk eller langvarig sykdom"
     }
+    val fravaerPerAar: Map<String, Float>
+        get() = fravaer.tilFravaerPerAar()
 }
 
 data class FravaerData(

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskSoeknad.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskSoeknad.kt
@@ -1,5 +1,6 @@
 package no.nav.helse.fritakagp.domain
 
+import com.fasterxml.jackson.annotation.JsonProperty
 import no.nav.helse.fritakagp.db.SimpleJsonbEntity
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -38,6 +39,7 @@ data class KroniskSoeknad(
     companion object {
         const val tittel = "Søknad om fritak fra arbeidsgiverperioden - kronisk eller langvarig sykdom"
     }
+    @get:JsonProperty(access = JsonProperty.Access.READ_ONLY)
     val fravaerPerAar: Set<FravaerPerAar>
         get() = fravaer.tilFravaerPerAar()
 }

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskSoeknad.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskSoeknad.kt
@@ -39,6 +39,7 @@ data class KroniskSoeknad(
     companion object {
         const val tittel = "Søknad om fritak fra arbeidsgiverperioden - kronisk eller langvarig sykdom"
     }
+
     @get:JsonProperty(access = JsonProperty.Access.READ_ONLY)
     val fravaerPerAar: Set<FravaerPerAar>
         get() = fravaer.tilFravaerPerAar()

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskSoeknad.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/KroniskSoeknad.kt
@@ -38,7 +38,7 @@ data class KroniskSoeknad(
     companion object {
         const val tittel = "Søknad om fritak fra arbeidsgiverperioden - kronisk eller langvarig sykdom"
     }
-    val fravaerPerAar: Map<String, Float>
+    val fravaerPerAar: Set<FravaerPerAar>
         get() = fravaer.tilFravaerPerAar()
 }
 

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/utils.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/utils.kt
@@ -20,6 +20,10 @@ fun sladdFnr(fnr: String): String {
     return fnr.take(6) + "*****"
 }
 
+fun Set<FravaerData>.tilFravaerPerAar(): Map<String, Float> =
+    groupBy { it.yearMonth.substring(0, 4) }
+        .mapValues { (_, fravaerData) -> fravaerData.map { it.antallDagerMedFravaer }.sum() }
+
 val TIMESTAMP_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm:ss")
 val DATE_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")
 val TIMESTAMP_FORMAT_MED_KL: DateTimeFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy 'kl.' HH:mm")

--- a/src/main/kotlin/no/nav/helse/fritakagp/domain/utils.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/domain/utils.kt
@@ -20,9 +20,12 @@ fun sladdFnr(fnr: String): String {
     return fnr.take(6) + "*****"
 }
 
-fun Set<FravaerData>.tilFravaerPerAar(): Map<String, Float> =
+data class FravaerPerAar(val aar: String, val antallDager: Float)
+
+fun Set<FravaerData>.tilFravaerPerAar(): Set<FravaerPerAar> =
     groupBy { it.yearMonth.substring(0, 4) }
-        .mapValues { (_, fravaerData) -> fravaerData.map { it.antallDagerMedFravaer }.sum() }
+        .map { (aar, fravaerData) -> FravaerPerAar(aar, fravaerData.map { it.antallDagerMedFravaer }.sum()) }
+        .toSet()
 
 val TIMESTAMP_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy HH:mm:ss")
 val DATE_FORMAT: DateTimeFormatter = DateTimeFormatter.ofPattern("dd.MM.yyyy")

--- a/src/test/kotlin/no/nav/helse/fritakagp/domain/KroniskSoeknadFravaerPerAarTest.kt
+++ b/src/test/kotlin/no/nav/helse/fritakagp/domain/KroniskSoeknadFravaerPerAarTest.kt
@@ -1,0 +1,27 @@
+package no.nav.helse.fritakagp.domain
+
+import no.nav.helse.KroniskTestData
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+class KroniskSoeknadFravaerPerAarTest {
+
+    @Test
+    fun `fravaerPerAar skal gruppere fravaer per år`() {
+        val fravaer = setOf(
+            FravaerData("2023-01", 3F),
+            FravaerData("2023-06", 4F),
+            FravaerData("2024-03", 5F),
+            FravaerData("2024-09", 2.5F),
+            FravaerData("2025-02", 6F)
+        )
+
+        val soeknad = KroniskTestData.soeknadKronisk.copy(fravaer = fravaer)
+        val result = soeknad.fravaerPerAar
+
+        assertEquals(3, result.size)
+        assertEquals(7F, result["2023"])
+        assertEquals(7.5F, result["2024"])
+        assertEquals(6F, result["2025"])
+    }
+}

--- a/src/test/kotlin/no/nav/helse/fritakagp/domain/KroniskSoeknadFravaerPerAarTest.kt
+++ b/src/test/kotlin/no/nav/helse/fritakagp/domain/KroniskSoeknadFravaerPerAarTest.kt
@@ -3,6 +3,7 @@ package no.nav.helse.fritakagp.domain
 import no.nav.helse.KroniskTestData
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 class KroniskSoeknadFravaerPerAarTest {
 
@@ -23,5 +24,26 @@ class KroniskSoeknadFravaerPerAarTest {
         assertEquals(7F, result.first { it.aar == "2023" }.antallDager)
         assertEquals(7.5F, result.first { it.aar == "2024" }.antallDager)
         assertEquals(6F, result.first { it.aar == "2025" }.antallDager)
+    }
+
+    @Test
+    fun `fravaerPerAar med tomt set skal returnere tomt set`() {
+        val soeknad = KroniskTestData.soeknadKronisk.copy(fravaer = emptySet())
+        val result = soeknad.fravaerPerAar
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `fravaerPerAar med null dager skal returnere 0`() {
+        val fravaer = setOf(
+            FravaerData("2023-03", 0F),
+            FravaerData("2023-07", 0F)
+        )
+
+        val soeknad = KroniskTestData.soeknadKronisk.copy(fravaer = fravaer)
+        val result = soeknad.fravaerPerAar
+
+        assertEquals(setOf(FravaerPerAar("2023", 0F)), result)
     }
 }

--- a/src/test/kotlin/no/nav/helse/fritakagp/domain/KroniskSoeknadFravaerPerAarTest.kt
+++ b/src/test/kotlin/no/nav/helse/fritakagp/domain/KroniskSoeknadFravaerPerAarTest.kt
@@ -20,8 +20,8 @@ class KroniskSoeknadFravaerPerAarTest {
         val result = soeknad.fravaerPerAar
 
         assertEquals(3, result.size)
-        assertEquals(7F, result["2023"])
-        assertEquals(7.5F, result["2024"])
-        assertEquals(6F, result["2025"])
+        assertEquals(7F, result.first { it.aar == "2023" }.antallDager)
+        assertEquals(7.5F, result.first { it.aar == "2024" }.antallDager)
+        assertEquals(6F, result.first { it.aar == "2025" }.antallDager)
     }
 }

--- a/src/test/resources/gravidKravRobotBeskrivelse.json
+++ b/src/test/resources/gravidKravRobotBeskrivelse.json
@@ -14,7 +14,8 @@
       "månedsinntekt": 2590.8,
       "gradering": 1.0,
       "dagsats": 0.0,
-      "belop": 0.0
+      "belop": 0.0,
+      "graderingProsent": 100.0
     }
   ],
   "harVedlegg": false,

--- a/src/test/resources/kroniskKravRobotBeskrivelse.json
+++ b/src/test/resources/kroniskKravRobotBeskrivelse.json
@@ -13,7 +13,8 @@
     "månedsinntekt" : 2590.8,
     "gradering" : 1.0,
     "dagsats" : 0.0,
-    "belop" : 0.0
+    "belop" : 0.0,
+    "graderingProsent" : 100.0
   } ],
   "harVedlegg" : false,
   "kontrollDager" : null,


### PR DESCRIPTION
**Problem:**
Vi ønsker å ha antall fravær per år og å gange gradering med 100 for å få prosent
pdfgen kan ikke gjøre logikken selv
For å legge til støtte i pdfgen må en PR godkjennes av et annet team og en ny docker image release lages

**Løsning:**
Legg til som computed felt i fritakagp appen
Vi kan legge til gange med 100 i pdfgen senere men om vi ønsker å prodsette på tirsdag er dette raskere.