### PR TITLE
Gi bruker tilgang til kvitteringer

### DIFF
--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/route/GravidRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/route/GravidRoutes.kt
@@ -82,7 +82,9 @@ fun Route.gravidRoutes(
                 if (soeknad == null) {
                     call.respond(HttpStatusCode.NotFound)
                 } else {
-                    authService.validerTilgangTilOrganisasjon(this, soeknad.virksomhetsnummer)
+                    if (soeknad.identitetsnummer != innloggetFnr) {
+                        authService.validerTilgangTilOrganisasjon(this, soeknad.virksomhetsnummer)
+                    }
 
                     soeknad.sendtAvNavn = soeknad.sendtAvNavn ?: pdlService.hentNavn(innloggetFnr)
                     soeknad.navn = soeknad.navn ?: pdlService.hentNavn(soeknad.identitetsnummer)
@@ -140,7 +142,9 @@ fun Route.gravidRoutes(
                         logger.warn("Gravid krav med id $kravId er slettet.")
                         call.respond(HttpStatusCode.NotFound)
                     } else {
-                        authService.validerTilgangTilOrganisasjon(this, krav.virksomhetsnummer)
+                        if (krav.identitetsnummer != innloggetFnr) {
+                            authService.validerTilgangTilOrganisasjon(this, krav.virksomhetsnummer)
+                        }
 
                         krav.sendtAvNavn = krav.sendtAvNavn ?: pdlService.hentNavn(innloggetFnr)
                         krav.navn = krav.navn ?: pdlService.hentNavn(krav.identitetsnummer)

--- a/src/main/kotlin/no/nav/helse/fritakagp/web/api/route/KroniskRoutes.kt
+++ b/src/main/kotlin/no/nav/helse/fritakagp/web/api/route/KroniskRoutes.kt
@@ -95,9 +95,10 @@ fun Route.kroniskRoutes(
                         logger.warn("Kronisk søknad ikke funnet.")
                         call.respond(HttpStatusCode.NotFound)
                     } else {
-                        logger.info("Sjekker om org har tilgang til kronisk søknad.")
-                        authService.validerTilgangTilOrganisasjon(this, soeknad.virksomhetsnummer)
-
+                        if (soeknad.identitetsnummer != innloggetFnr) {
+                            logger.info("Sjekker om org har tilgang til kronisk søknad.")
+                            authService.validerTilgangTilOrganisasjon(this, soeknad.virksomhetsnummer)
+                        }
                         logger.info("Hent personinfo fra PDL.")
                         soeknad.sendtAvNavn = soeknad.sendtAvNavn ?: pdlService.hentNavn(innloggetFnr)
                         soeknad.navn = soeknad.navn ?: pdlService.hentNavn(soeknad.identitetsnummer)
@@ -176,7 +177,9 @@ fun Route.kroniskRoutes(
                         logger.warn("Kronisk krav med id $kravId er slettet.")
                         call.respond(HttpStatusCode.NotFound)
                     } else {
-                        authService.validerTilgangTilOrganisasjon(this, krav.virksomhetsnummer)
+                        if (krav.identitetsnummer != innloggetFnr) {
+                            authService.validerTilgangTilOrganisasjon(this, krav.virksomhetsnummer)
+                        }
                         logger.info("Hent personinfo fra PDL.")
                         krav.sendtAvNavn = krav.sendtAvNavn ?: pdlService.hentNavn(innloggetFnr)
                         krav.navn = krav.navn ?: pdlService.hentNavn(krav.identitetsnummer)

--- a/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/GravidKravHTTPTests.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/GravidKravHTTPTests.kt
@@ -7,13 +7,18 @@ import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
+import io.mockk.every
 import no.nav.helse.GravidTestData
 import no.nav.helse.fritakagp.db.GravidKravRepository
 import no.nav.helse.fritakagp.domain.Arbeidsgiverperiode
 import no.nav.helse.fritakagp.domain.GravidKrav
 import no.nav.helse.fritakagp.domain.KravStatus
 import no.nav.helse.fritakagp.web.api.resreq.validation.ValidationProblem
+import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
+import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
+import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.koin.test.inject
@@ -22,20 +27,33 @@ import java.time.LocalDate
 class GravidKravHTTPTests : SystemTestBase() {
     private val kravGravidUrl = "/fritak-agp-api/api/v1/gravid/krav"
 
+    @AfterEach
+    fun cleanUp() {
+        val repo by inject<GravidKravRepository>()
+        repo.delete(GravidTestData.gravidKrav.id)
+    }
+
     @Test
-    @Disabled
-    internal fun `Returnerer kravet når korrekt bruker er innlogget, 403 når ikke`() = suspendableTest {
+    internal fun `Returnerer 403 når feil bruker er innlogget`() = suspendableTest {
         val repo by inject<GravidKravRepository>()
 
-        repo.insert(GravidTestData.gravidKrav)
+        repo.insert(GravidTestData.gravidKrav.copy(virksomhetsnummer = Orgnr.genererGyldig().verdi))
+        val fnr = Fnr.genererGyldig()
         val response =
             httpClient.get {
                 appUrl("$kravGravidUrl/${GravidTestData.gravidKrav.id}")
                 contentType(ContentType.Application.Json)
-                loggedInAs("123456789")
+                loggedInAs(fnr.verdi)
             }
 
         assertThat(response.status).isEqualTo(HttpStatusCode.Forbidden)
+    }
+
+    @Test
+    internal fun `Returnerer kravet når korrekt bruker er innlogget`() = suspendableTest {
+        val repo by inject<GravidKravRepository>()
+        val orgnr = Orgnr.genererGyldig().verdi
+        repo.insert(GravidTestData.gravidKrav.copy(virksomhetsnummer = orgnr))
 
         val accessGrantedForm = httpClient.get {
             appUrl("$kravGravidUrl/${GravidTestData.gravidKrav.id}")
@@ -43,7 +61,10 @@ class GravidKravHTTPTests : SystemTestBase() {
             loggedInAs(GravidTestData.gravidKrav.identitetsnummer)
         }
 
-        assertThat(accessGrantedForm).isEqualTo(GravidTestData.gravidKrav)
+        assertThat(accessGrantedForm.body<GravidKrav>())
+            .usingRecursiveComparison()
+            .ignoringFields("referansenummer")
+            .isEqualTo(GravidTestData.gravidKrav.copy(virksomhetsnummer = orgnr))
     }
 
     @Test

--- a/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/GravidKravHTTPTests.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/GravidKravHTTPTests.kt
@@ -7,7 +7,6 @@ import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
-import io.mockk.every
 import no.nav.helse.GravidTestData
 import no.nav.helse.fritakagp.db.GravidKravRepository
 import no.nav.helse.fritakagp.domain.Arbeidsgiverperiode
@@ -19,7 +18,6 @@ import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.koin.test.inject
 import java.time.LocalDate

--- a/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/KroniskKravHTTPTests.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/KroniskKravHTTPTests.kt
@@ -14,14 +14,14 @@ import no.nav.helse.fritakagp.domain.Arbeidsgiverperiode
 import no.nav.helse.fritakagp.domain.KravStatus
 import no.nav.helse.fritakagp.domain.KroniskKrav
 import no.nav.helse.fritakagp.web.api.resreq.validation.ValidationProblem
+import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
+import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
+import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.koin.test.inject
 import java.time.LocalDate
-import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
-import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
-import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 
 class KroniskKravHTTPTests : SystemTestBase() {
     private val kravKroniskUrl = "/fritak-agp-api/api/v1/kronisk/krav"

--- a/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/KroniskKravHTTPTests.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/KroniskKravHTTPTests.kt
@@ -15,12 +15,56 @@ import no.nav.helse.fritakagp.domain.KravStatus
 import no.nav.helse.fritakagp.domain.KroniskKrav
 import no.nav.helse.fritakagp.web.api.resreq.validation.ValidationProblem
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.koin.test.inject
 import java.time.LocalDate
+import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
+import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
+import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 
 class KroniskKravHTTPTests : SystemTestBase() {
     private val kravKroniskUrl = "/fritak-agp-api/api/v1/kronisk/krav"
+
+    @AfterEach
+    fun cleanUp() {
+        val repo by inject<KroniskKravRepository>()
+        repo.delete(KroniskTestData.kroniskKrav.id)
+    }
+
+    @Test
+    internal fun `Returnerer 403 når feil bruker er innlogget`() = suspendableTest {
+        val repo by inject<KroniskKravRepository>()
+
+        repo.insert(KroniskTestData.kroniskKrav.copy(virksomhetsnummer = Orgnr.genererGyldig().verdi))
+        val fnr = Fnr.genererGyldig()
+        val response = httpClient.get {
+            appUrl("$kravKroniskUrl/${KroniskTestData.kroniskKrav.id}")
+            contentType(ContentType.Application.Json)
+            loggedInAs(fnr.verdi)
+        }
+
+        assertThat(response.status).isEqualTo(HttpStatusCode.Forbidden)
+    }
+
+    @Test
+    internal fun `Returnerer kravet når korrekt bruker er innlogget`() = suspendableTest {
+        val repo by inject<KroniskKravRepository>()
+
+        val orgnr = Orgnr.genererGyldig().verdi
+        repo.insert(KroniskTestData.kroniskKrav.copy(virksomhetsnummer = orgnr))
+
+        val response = httpClient.get {
+            appUrl("$kravKroniskUrl/${KroniskTestData.kroniskKrav.id}")
+            contentType(ContentType.Application.Json)
+            loggedInAs(KroniskTestData.kroniskKrav.identitetsnummer)
+        }
+
+        assertThat(response.body<KroniskKrav>())
+            .usingRecursiveComparison()
+            .ignoringFields("referansenummer")
+            .isEqualTo(KroniskTestData.kroniskKrav.copy(virksomhetsnummer = orgnr))
+    }
 
     @Test
     fun `Gir not found når kravet er slettet`() = suspendableTest {
@@ -168,5 +212,6 @@ class KroniskKravHTTPTests : SystemTestBase() {
             setBody(KroniskTestData.kroniskKravRequestValid)
         }
         assertThat(response.status).isEqualTo(HttpStatusCode.Conflict)
+        repo.delete(krav.id)
     }
 }

--- a/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/SoeknadOrgTilgangHTTPTests.kt
+++ b/src/test/kotlin/no/nav/helse/slowtests/systemtests/api/SoeknadOrgTilgangHTTPTests.kt
@@ -8,6 +8,8 @@ import no.nav.helse.GravidTestData
 import no.nav.helse.KroniskTestData
 import no.nav.helse.fritakagp.db.GravidSoeknadRepository
 import no.nav.helse.fritakagp.db.KroniskSoeknadRepository
+import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
+import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.koin.test.inject
@@ -24,10 +26,26 @@ class SoeknadOrgTilgangHTTPTests : SystemTestBase() {
         val response = httpClient.get {
             appUrl("/fritak-agp-api/api/v1/gravid/soeknad/${soeknad.id}")
             contentType(ContentType.Application.Json)
-            loggedInAs(GravidTestData.validIdentitetsnummer)
+            val fnr = Fnr.genererGyldig()
+            loggedInAs(fnr.verdi)
         }
-
         assertThat(response.status).isEqualTo(HttpStatusCode.Forbidden)
+    }
+
+    @Test
+    fun `gravid soeknad - bruker får tilgang til skjema på vegne av seg selv`() = suspendableTest {
+        val repo by inject<GravidSoeknadRepository>()
+        val fnr = Fnr.genererGyldig()
+
+        val soeknad = GravidTestData.soeknadGravid.copy(identitetsnummer = fnr.verdi, id = UUID.randomUUID(), virksomhetsnummer = "999999999")
+        repo.insert(soeknad)
+
+        val response = httpClient.get {
+            appUrl("/fritak-agp-api/api/v1/gravid/soeknad/${soeknad.id}")
+            contentType(ContentType.Application.Json)
+            loggedInAs(fnr.verdi)
+        }
+        assertThat(response.status).isEqualTo(HttpStatusCode.OK)
     }
 
     @Test
@@ -35,13 +53,28 @@ class SoeknadOrgTilgangHTTPTests : SystemTestBase() {
         val repo by inject<KroniskSoeknadRepository>()
         val soeknad = KroniskTestData.soeknadKronisk.copy(id = UUID.randomUUID(), virksomhetsnummer = "999999999")
         repo.insert(soeknad)
-
         val response = httpClient.get {
             appUrl("/fritak-agp-api/api/v1/kronisk/soeknad/${soeknad.id}")
             contentType(ContentType.Application.Json)
-            loggedInAs(KroniskTestData.validIdentitetsnummer)
+            val fnr = Fnr.genererGyldig()
+            loggedInAs(fnr.verdi)
         }
 
         assertThat(response.status).isEqualTo(HttpStatusCode.Forbidden)
+    }
+
+    @Test
+    fun `kronisk soeknad - bruker får tilgang til skjema på vegne av seg selv`() = suspendableTest {
+        val repo by inject<KroniskSoeknadRepository>()
+        val fnr = Fnr.genererGyldig()
+        val soeknad = KroniskTestData.soeknadKronisk.copy(identitetsnummer = fnr.verdi, id = UUID.randomUUID(), virksomhetsnummer = "999999999")
+        repo.insert(soeknad)
+        val response = httpClient.get {
+            appUrl("/fritak-agp-api/api/v1/kronisk/soeknad/${soeknad.id}")
+            contentType(ContentType.Application.Json)
+            loggedInAs(fnr.verdi)
+        }
+
+        assertThat(response.status).isEqualTo(HttpStatusCode.OK)
     }
 }


### PR DESCRIPTION
Skjemaet blir tilgjengeligjort til bruker via lenker på min side.
Etter noen endringer som ble gjort på tilgangsstyringen i kobling til kvitteringer i dialogporten, ble skjemaet gjort utligjengelig for bruker.

Denne pren legger til sjekk på fnr til innlogget bruker. 
Hvis det er samme fnr som skjemaet er på vegne av, vises kvittering til bruker.